### PR TITLE
upgrade hardhat network to ^2.12.0

### DIFF
--- a/ops/docker/hardhat/package.json
+++ b/ops/docker/hardhat/package.json
@@ -7,6 +7,6 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^10.0.0",
-    "hardhat": "^2.9.6"
+    "hardhat": "^2.12.0"
   }
 }


### PR DESCRIPTION
https://github.com/NomicFoundation/hardhat/pull/2581
Make `eth_getStorageAt` spec-compliant. This means that the storage slot argument **must** have a length of 32 bytes (a hex-encoded string of length 66).  For forge client.