### PR TITLE
Peer check 

### DIFF
--- a/l2geth/eth/backend.go
+++ b/l2geth/eth/backend.go
@@ -240,7 +240,7 @@ func New(ctx *node.ServiceContext, config *Config) (*Ethereum, error) {
 	rollupGpo := gasprice.NewRollupOracle()
 	eth.APIBackend.rollupGpo = rollupGpo
 	eth.syncService.RollupGpo = rollupGpo
-
+	eth.protocolManager.setMinerCheck(eth.miner.Mining)
 	if _, ok := eth.engine.(*clique.Clique); ok {
 		schedulerInst, err := clique.NewScheduler(
 			chainDb,

--- a/l2geth/eth/consensus_handler.go
+++ b/l2geth/eth/consensus_handler.go
@@ -84,9 +84,11 @@ func (pm *ProtocolManager) consensusHandler(peer *p2p.Peer, rw p2p.MsgReadWriter
 
 		// Handle incoming messages until the connection is torn down
 		for {
-			//if err := pm.checkPeer(p); err != nil {
-			//	return err
-			//}
+			if pm.minerCheck() {
+				if err := pm.checkPeer(p); err != nil {
+					return err
+				}
+			}
 
 			if err := pm.handleConsensusMsg(p); err != nil {
 				p.Log().Debug("Ethereum consensus message handling failed", "err", err)

--- a/l2geth/eth/handler.go
+++ b/l2geth/eth/handler.go
@@ -85,6 +85,7 @@ type ProtocolManager struct {
 	consensusPeers *peerSet
 	schedulerInst  *clique.Scheduler
 	etherbase      common.Address
+	minerCheck     func() bool
 
 	eventMux      *event.TypeMux
 	txsCh         chan core.NewTxsEvent
@@ -246,6 +247,10 @@ func (pm *ProtocolManager) makeProtocol(version uint) p2p.Protocol {
 			return nil
 		},
 	}
+}
+
+func (pm *ProtocolManager) setMinerCheck(check func() bool) {
+	pm.minerCheck = check
 }
 
 func (pm *ProtocolManager) removePeer(id string) {


### PR DESCRIPTION
Add peer check when scheduler has p2p connection with other nodes, only sequencers who registered in the contract and selected as sequencer by scheduler can connect with scheduler.