### PR TITLE
fix bug in tss slash process

### DIFF
--- a/tss/manager/manage.go
+++ b/tss/manager/manage.go
@@ -260,10 +260,7 @@ func (m Manager) SignStateBatch(request tss.SignStateRequest) ([]byte, error) {
 		absents := make([]string, 0)
 		for _, node := range tssInfo.TssMembers {
 			if !slices.ExistsIgnoreCase(ctx.Approvers(), node) {
-				addr, _ := tss.NodeToAddress(node)
-				if !m.store.IsInSlashing(addr) {
-					absents = append(absents, node)
-				}
+				absents = append(absents, node)
 			}
 		}
 		if err = m.afterSignStateBatch(ctx, request.StateRoots, absents); err != nil {

--- a/tss/manager/router/registry.go
+++ b/tss/manager/router/registry.go
@@ -69,7 +69,7 @@ func (registry *Registry) SignStateHandler() gin.HandlerFunc {
 
 func (registry *Registry) ResetHeightHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		heightStr := c.Param("height")
+		heightStr := c.PostForm("height")
 		height, err := strconv.Atoi(heightStr)
 		if err != nil {
 			c.String(http.StatusInternalServerError, "wrong height format")

--- a/tss/node/cmd/tssnode/cmd.go
+++ b/tss/node/cmd/tssnode/cmd.go
@@ -38,17 +38,17 @@ func Command() *cobra.Command {
 			return runNode(cmd)
 		},
 	}
-
+	cmd.Flags().BoolP("debug", "d", false, "log level,default info")
 	return cmd
 }
 
 func runNode(cmd *cobra.Command) error {
 	nonProd, _ := cmd.Flags().GetBool("non-prod")
 	waitPeersFullConnected, _ := cmd.Flags().GetBool("full")
-	debug,_ := cmd.Flags().GetBool("debug")
+	debug, _ := cmd.Flags().GetBool("debug")
 	if debug {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	}else {
+	} else {
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
 	cfg := tss.GetConfigFromCmd(cmd)
@@ -78,7 +78,7 @@ func runNode(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	observer = observer.SetHook(slash.NewSlashing(store, store, cfg.MissSignedNumber))
+	observer = observer.SetHook(slash.NewSlashingNode(store, store))
 	observer.Start()
 
 	//new tss server instance

--- a/tss/node/signer/delete_slash.go
+++ b/tss/node/signer/delete_slash.go
@@ -2,6 +2,7 @@ package signer
 
 import (
 	"context"
+	tss "github.com/mantlenetworkio/mantle/tss/common"
 	"math/big"
 	"time"
 
@@ -46,6 +47,17 @@ func (p *Processor) handleSlashing(si slash.SlashingInfo) {
 		if found { // this slashing is confirmed on ethereum
 			p.nodeStore.RemoveSlashingInfo(si.Address, si.BatchIndex)
 		}
+		return
+	}
+
+	unJailMembers, err := p.tssGroupManagerCaller.GetTssGroupUnJailMembers(nil)
+	if err != nil {
+		log.Error("failed to GetTssGroupUnJailMembers", "err", err)
+		return
+	}
+	if !tss.IsAddrExist(unJailMembers, si.Address) {
+		log.Warn("can not slash the address are not unJailed", "address", si.Address.String())
+		p.nodeStore.RemoveSlashingInfo(si.Address, si.BatchIndex)
 		return
 	}
 

--- a/tss/node/signer/process.go
+++ b/tss/node/signer/process.go
@@ -3,6 +3,7 @@ package signer
 import (
 	"context"
 	"crypto/ecdsa"
+	"github.com/mantlenetworkio/mantle/tss/bindings/tgm"
 	"math/big"
 	"sync"
 	"time"
@@ -58,6 +59,7 @@ type Processor struct {
 	tssStakingSlashingAddress string
 	taskInterval              time.Duration
 	tssStakingSlashingCaller  *tsh.TssStakingSlashingCaller
+	tssGroupManagerCaller     *tgm.TssGroupManagerCaller
 	tssQueryService           managertypes.TssQueryService
 	l1ConfirmBlocks           int
 	confirmReceiptTimeout     time.Duration
@@ -92,6 +94,10 @@ func NewProcessor(cfg common.Configuration, contx context.Context, tssInstance t
 	}
 	l2Client, err := DialL2EthClientWithTimeout(ctx, cfg.Node.L2EthRpc, cfg.Node.DisableHTTP2)
 	tssStakingSlashingCaller, err := tsh.NewTssStakingSlashingCaller(ethc.HexToAddress(cfg.TssStakingSlashContractAddress), l1Cli)
+	if err != nil {
+		return nil, err
+	}
+	tssGroupManagerCaller, err := tgm.NewTssGroupManagerCaller(ethc.HexToAddress(cfg.TssGroupContractAddress), l1Cli)
 	if err != nil {
 		return nil, err
 	}
@@ -133,6 +139,7 @@ func NewProcessor(cfg common.Configuration, contx context.Context, tssInstance t
 		tssStakingSlashingAddress: cfg.TssStakingSlashContractAddress,
 		taskInterval:              taskIntervalDur,
 		tssStakingSlashingCaller:  tssStakingSlashingCaller,
+		tssGroupManagerCaller:     tssGroupManagerCaller,
 		tssQueryService:           queryService,
 		l1ConfirmBlocks:           cfg.L1ConfirmBlocks,
 		confirmReceiptTimeout:     receiptConfirmTimeoutDur,

--- a/tss/node/signer/verify_slash.go
+++ b/tss/node/signer/verify_slash.go
@@ -50,7 +50,7 @@ func (p *Processor) VerifySlash() {
 					}
 				} else if askRequest.SignType == common.SlashTypeLiveness {
 					found, info := p.nodeStore.GetSlashingInfo(askRequest.Address, askRequest.BatchIndex)
-					logger.Info().Msgf("--------- found value %s ", found)
+					logger.Info().Msgf("address %s,batch index %d, found value %s ", askRequest.Address, askRequest.BatchIndex, found)
 					if found && info.SlashType == common.SlashTypeLiveness {
 						ret = true
 					}

--- a/tss/slash/slash_node.go
+++ b/tss/slash/slash_node.go
@@ -1,0 +1,46 @@
+package slash
+
+import (
+	"errors"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/mantlenetworkio/mantle/l2geth/log"
+	tss "github.com/mantlenetworkio/mantle/tss/common"
+	"github.com/mantlenetworkio/mantle/tss/index"
+)
+
+type SlashingNode struct {
+	stateBatchStore index.StateBatchStore
+	slashingStore   SlashingStore
+}
+
+func NewSlashingNode(sbs index.StateBatchStore, ss SlashingStore) SlashingNode {
+	return SlashingNode{
+		stateBatchStore: sbs,
+		slashingStore:   ss,
+	}
+}
+
+func (s SlashingNode) AfterStateBatchIndexed(root [32]byte) error {
+	found, stateBatch := s.stateBatchStore.GetStateBatch(root)
+	if !found {
+		return errors.New("can not find the state batch with root: " + hexutil.Encode(root[:]))
+	}
+
+	log.Info("--------", "working", len(stateBatch.WorkingNodes), "no working", len(stateBatch.AbsentNodes))
+
+	// update signingInfo for absent nodes
+	for _, absentNode := range stateBatch.AbsentNodes {
+		address, err := tss.NodeToAddress(absentNode)
+		if err != nil {
+			return err
+		}
+		s.slashingStore.SetSlashingInfo(SlashingInfo{
+			Address:    address,
+			ElectionId: stateBatch.ElectionId,
+			BatchIndex: stateBatch.BatchIndex,
+			SlashType:  tss.SlashTypeLiveness,
+		})
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Goals of PR

Core changes:

- Remove the logic of calculating slash information for the tssnode portion and directly cache the slash information for nodes that do not participate each time.
- Put the logic of checking if tssnode is slashed in tssmanager, and let tssnode only verify.


