### PR TITLE
fix tss imports

### DIFF
--- a/tss/manager/cmd.go
+++ b/tss/manager/cmd.go
@@ -10,12 +10,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/mantlenetworkio/mantle/tss/index"
-	"github.com/mantlenetworkio/mantle/tss/manager/l1chain"
-	"github.com/mantlenetworkio/mantle/tss/manager/store"
-	"github.com/mantlenetworkio/mantle/tss/slash"
-
-	"github.com/gin-gonic/gin"
 	"github.com/mantlenetworkio/mantle/l2geth/log"
 	"github.com/mantlenetworkio/mantle/tss/common"
 	"github.com/mantlenetworkio/mantle/tss/index"
@@ -24,6 +18,8 @@ import (
 	"github.com/mantlenetworkio/mantle/tss/manager/store"
 	"github.com/mantlenetworkio/mantle/tss/slash"
 	"github.com/mantlenetworkio/mantle/tss/ws/server"
+
+	"github.com/gin-gonic/gin"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
# Goals of PR

Core changes:

fixed this error:
```
# github.com/mantlenetworkio/mantle/tss/manager
manager/cmd.go:21:2: index redeclared in this block
	manager/cmd.go:13:2: other declaration of index
manager/cmd.go:21:2: imported and not used: "github.com/mantlenetworkio/mantle/tss/index"
manager/cmd.go:22:2: l1chain redeclared in this block
	manager/cmd.go:14:2: other declaration of l1chain
manager/cmd.go:22:2: imported and not used: "github.com/mantlenetworkio/mantle/tss/manager/l1chain"
manager/cmd.go:24:2: store redeclared in this block
	manager/cmd.go:15:2: other declaration of store
manager/cmd.go:24:2: imported and not used: "github.com/mantlenetworkio/mantle/tss/manager/store"
manager/cmd.go:25:2: slash redeclared in this block
	manager/cmd.go:16:2: other declaration of slash
manager/cmd.go:25:2: imported and not used: "github.com/mantlenetworkio/mantle/tss/slash"
```