### PR TITLE
[R4R] consensys audit fix for mt-batcher and mt-challenger

### DIFF
--- a/mt-batcher/services/sequencer/driver.go
+++ b/mt-batcher/services/sequencer/driver.go
@@ -240,7 +240,8 @@ func (d *Driver) TxAggregator(ctx context.Context, start, end *big.Int) (transac
 	for i := new(big.Int).Set(start); i.Cmp(end) < 0; i.Add(i, bigOne) {
 		block, err := d.Cfg.L2Client.BlockByNumber(ctx, i)
 		if err != nil {
-			return nil, big.NewInt(0), big.NewInt(0)
+			log.Error("get blockNumber from l2 fail", "err", err)
+			continue
 		}
 		txs := block.Transactions()
 		if len(txs) != 1 {
@@ -276,6 +277,7 @@ func (d *Driver) TxAggregator(ctx context.Context, start, end *big.Int) (transac
 		txMetaByte, err := json.Marshal(txMeta)
 		if err != nil {
 			log.Error("tx meta json marshal error", "err", err)
+			continue
 		}
 		batchTx := common3.BatchTx{
 			BlockNumber: i.Bytes(),

--- a/mt-challenger/challenger/challenger.go
+++ b/mt-challenger/challenger/challenger.go
@@ -615,6 +615,7 @@ func (c *Challenger) eventLoop() {
 			batchIndex, ok := c.LevelDBStore.GetLatestBatchIndex()
 			if !ok {
 				log.Error("MtChallenger get batch index from db fail", "err", err)
+				continue
 			}
 			if c.Cfg.CheckerBatchIndex > latestBatchIndex.Uint64() {
 				log.Info("MtChallenger Batch Index", "DbBatchIndex", batchIndex, "ContractBatchIndex", latestBatchIndex.Uint64()-c.Cfg.CheckerBatchIndex)


### PR DESCRIPTION
# Goals of PR

Core changes:

- TxAggregator() Might Cause a Panic Medium
- eventLoop() Does Not Abort the Current Ticker Loop if levelDB.GetLatestBatchIndex() Fails Major

Notes:

- no

Related Issues:

- https://github.com/mantlenetworkio/mantle/issues/1042