### PR TITLE
[gasoracle]fix: bounds check for eth_price, mnt_price & token_ratio

### DIFF
--- a/gas-oracle/tokenprice/tokenprice_test.go
+++ b/gas-oracle/tokenprice/tokenprice_test.go
@@ -1,6 +1,7 @@
 package tokenprice
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -67,7 +68,7 @@ func TestGetTokenPriceWithOneDollarTokenRatioMode3(t *testing.T) {
 
 	ratio, err := tokenPricer.PriceRatioWithMode()
 	require.NoError(t, err)
-	require.Equal(t, DefaultETHPrice, int(ratio))
+	require.Equal(t, DefaultETHPrice, big.NewFloat(ratio))
 	t.Logf("ratio:%v", ratio)
 }
 
@@ -76,6 +77,6 @@ func TestGetTokenPriceWithDefaultTokenRatioMode(t *testing.T) {
 
 	ratio, err := tokenPricer.PriceRatioWithMode()
 	require.NoError(t, err)
-	require.Equal(t, DefaultTokenRatio, int(ratio))
+	require.Equal(t, DefaultTokenRatio, ratio)
 	t.Logf("ratio:%v", ratio)
 }

--- a/gas-oracle/tokenprice/tokenprice_uniswap.go
+++ b/gas-oracle/tokenprice/tokenprice_uniswap.go
@@ -55,7 +55,10 @@ func (c *Client) getTokenPricesFromUniswap() (float64, float64, error) {
 		return 0, 0, err
 	}
 
-	return float64(eth2bitPrice), float64(eth2usdtPrice), nil
+	tokenRatio := determineTokenRatio(float64(eth2bitPrice))
+	ethPrice, _ := determineETHPrice(big.NewFloat(float64(eth2usdtPrice))).Float64()
+
+	return tokenRatio, ethPrice, nil
 }
 
 // getTokenPriceFromUniswap estimate to execute swapping from_token to to_token to get token price


### PR DESCRIPTION
resolves #1054 

# Goals of PR

Core changes:

- bounds check for eth_price, mnt_price & token_ratio

- #1054 
