### PR TITLE
batch-submitter and mt-batcher code optimization for nonce, under pri…

### DIFF
--- a/bss-core/txmgr/txmgr.go
+++ b/bss-core/txmgr/txmgr.go
@@ -145,6 +145,7 @@ func (m *SimpleTxManager) Send(
 				return
 			}
 			log.Error(name+" unable to update txn gas price", "err", err)
+			cancel()
 			return
 		}
 
@@ -330,7 +331,8 @@ func waitMined(
 
 // CalcGasFeeCap deterministically computes the recommended gas fee cap given
 // the base fee and gasTipCap. The resulting gasFeeCap is equal to:
-//   gasTipCap + 2*baseFee.
+//
+//	gasTipCap + 2*baseFee.
 func CalcGasFeeCap(baseFee, gasTipCap *big.Int) *big.Int {
 	return new(big.Int).Add(
 		gasTipCap,

--- a/mt-batcher/txmgr/txmgr.go
+++ b/mt-batcher/txmgr/txmgr.go
@@ -66,6 +66,7 @@ func (m *SimpleTxManager) Send(ctx context.Context, updateGasPrice UpdateGasPric
 				return
 			}
 			log.Error("MtBatcher update txn gas price fail", "err", err)
+			cancel()
 			return
 		}
 


### PR DESCRIPTION
# Goals of PR

Core changes:

batch-submitter and mt-batcher code optimization
- Nonce to low padding for a long time causes rollup to pause
- Under transaction price padding for a long time causes rollup to pause
- execution reverted: DataLayrServiceManager.confirmDataStore: provided calldata does not match corresponding stored hash from initDataStore padding for a long time causes rollup to pause

Notes:

- Nonce to low can use MT_BATCHER_SAFE_ABORT_NONCE_TOO_LOW_COUNT config solve, if it value is 1, batch-submitter and mt-batcher will retry 1 times, if it value is n, batch-submitter and mt-batcher will retry n times. We can config it value 1 to solve many times retry.

Related Issues:

- https://github.com/mantlenetworkio/mantle/issues/1016
