### PR TITLE
R4R: add jwt to batch-submitter

### DIFF
--- a/batch-submitter/batch_submitter.go
+++ b/batch-submitter/batch_submitter.go
@@ -105,7 +105,10 @@ func Main(gitVersion string) func(ctx *cli.Context) error {
 			return err
 		}
 
-		tssClient := tss.NewClient(cfg.TssClientUrl)
+		tssClient, err := tss.NewClient(cfg.TssClientUrl, cfg.JwtSecret)
+		if err != nil {
+			return err
+		}
 		log.Info("Configured tss client", "url", cfg.TssClientUrl)
 
 		if cfg.MetricsServerEnable {

--- a/batch-submitter/config.go
+++ b/batch-submitter/config.go
@@ -63,6 +63,9 @@ type Config struct {
 	// Tss manager client Url
 	TssClientUrl string
 
+	// jwt access token
+	JwtSecret string
+
 	// eigen layer upgrade block.
 	DaUpgradeBlock uint64
 
@@ -238,6 +241,7 @@ func NewConfig(ctx *cli.Context) (Config, error) {
 		L1EthRpc:                  ctx.GlobalString(flags.L1EthRpcFlag.Name),
 		L2EthRpc:                  ctx.GlobalString(flags.L2EthRpcFlag.Name),
 		TssClientUrl:              ctx.GlobalString(flags.TssClientUrl.Name),
+		JwtSecret:                 ctx.GlobalString(flags.JwtSecret.Name),
 		DaUpgradeBlock:            ctx.GlobalUint64(flags.DaUpgradeBlockFlag.Name),
 		DAAddress:                 ctx.GlobalString(flags.DaAddressFlag.Name),
 		CTCAddress:                ctx.GlobalString(flags.CTCAddressFlag.Name),

--- a/batch-submitter/flags/flags.go
+++ b/batch-submitter/flags/flags.go
@@ -46,6 +46,12 @@ var (
 		Required: true,
 		EnvVar:   "TSS_CLIENT_RPC",
 	}
+	JwtSecret = cli.StringFlag{
+		Name:     "jwt-secret",
+		Usage:    "jet access secret",
+		Required: true,
+		EnvVar:   "JWT_SECRET",
+	}
 	DaAddressFlag = cli.StringFlag{
 		Name:     "da-address",
 		Usage:    "Address of the da contract",

--- a/batch-submitter/flags/flags.go
+++ b/batch-submitter/flags/flags.go
@@ -345,6 +345,7 @@ var requiredFlags = []cli.Flag{
 	L1EthRpcFlag,
 	L2EthRpcFlag,
 	TssClientUrl,
+	JwtSecret,
 	DaAddressFlag,
 	DaUpgradeBlockFlag,
 	CTCAddressFlag,

--- a/batch-submitter/tss-client/client.go
+++ b/batch-submitter/tss-client/client.go
@@ -2,9 +2,17 @@ package tss_client
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/go-resty/resty/v2"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/mantlenetworkio/mantle/l2geth/common/hexutil"
 	"github.com/mantlenetworkio/mantle/tss/common"
 	"github.com/syndtr/goleveldb/leveldb/errors"
+)
+
+const (
+	JwtSecretLength = 32
 )
 
 var errTssHTTPError = errors.New("tss http error")
@@ -22,9 +30,29 @@ type TssResponse struct {
 	RollBack  bool   `json:"roll_back"`
 }
 
-func NewClient(url string) *Client {
+func NewClient(url string, jwtSecretStr string) (*Client, error) {
+	jwtSecret, err := hexutil.Decode(jwtSecretStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid jwt secret %s", err.Error())
+	}
+	if len(jwtSecret) != JwtSecretLength {
+		return nil, fmt.Errorf("invalid jwt secret length, expected length %d, actual length %d",
+			JwtSecretLength, len(jwtSecret))
+	}
 	client := resty.New()
 	client.SetHostURL(url)
+	client.SetAuthScheme("Bearer")
+	client.OnBeforeRequest(func(c *resty.Client, r *resty.Request) error {
+		token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"iat": &jwt.NumericDate{Time: time.Now()},
+		})
+		s, err := token.SignedString(jwtSecret[:])
+		if err != nil {
+			return fmt.Errorf("failed to create JWT token: %w", err)
+		}
+		r.Token = s
+		return nil
+	})
 	client.OnAfterResponse(func(c *resty.Client, r *resty.Response) error {
 		statusCode := r.StatusCode()
 		if statusCode >= 400 {
@@ -36,7 +64,7 @@ func NewClient(url string) *Client {
 	})
 	return &Client{
 		client: client,
-	}
+	}, nil
 }
 
 func (c *Client) GetSignStateBatch(BatchData common.SignStateRequest) ([]byte, error) {


### PR DESCRIPTION
# Goals of PR

Core changes:

- Add jwt access token to batch-submitter

Notes:

- Previously, I added jwt access token to tss server, however, the client still doesn't support jwt token. In this PR, I add the jwt access token to client.

Related Issues:

- https://github.com/mantlenetworkio/mantle/pull/854
