### PR TITLE
[R4R][gasoracle]feat: add metrics for gasoracle

### DIFF
--- a/gas-oracle/gasprices/gas_price_updater_test.go
+++ b/gas-oracle/gasprices/gas_price_updater_test.go
@@ -19,7 +19,7 @@ func makeTestGasPricerAndUpdater(curPrice uint64) (*GasPricer, *GasPriceUpdater,
 	getGasTarget := func() float64 { return gpsTarget }
 	epochLengthSeconds := uint64(10)
 	averageBlockGasLimit := uint64(11000000)
-	tokenPricer := tokenprice.NewClient("https://api.bybit.com", 3, 0)
+	tokenPricer := tokenprice.NewClient("", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 0)
 	// Based on our 10 second epoch, we are targeting 3 blocks per epoch.
 	gasPricer, err := NewGasPricer(curPrice, 1, tokenPricer, getGasTarget, 10)
 	if err != nil {

--- a/gas-oracle/main.go
+++ b/gas-oracle/main.go
@@ -49,14 +49,11 @@ func main() {
 			return err
 		}
 
-		if err := gpo.Start(); err != nil {
-			return err
-		}
-
 		if config.MetricsEnabled {
 			address := fmt.Sprintf("%s:%d", config.MetricsHTTP, config.MetricsPort)
 			log.Info("Enabling stand-alone metrics HTTP endpoint", "address", address)
 			ometrics.Setup(address)
+			ometrics.InitAndRegisterStats(ometrics.DefaultRegistry)
 		}
 
 		if config.MetricsEnableInfluxDB {
@@ -66,6 +63,10 @@ func main() {
 			password := config.MetricsInfluxDBPassword
 			log.Info("Enabling metrics export to InfluxDB", "endpoint", endpoint, "username", username, "database", database)
 			go influxdb.InfluxDBWithTags(ometrics.DefaultRegistry, 10*time.Second, endpoint, database, username, password, "geth.", make(map[string]string))
+		}
+
+		if err := gpo.Start(); err != nil {
+			return err
 		}
 
 		gpo.Wait()

--- a/gas-oracle/metrics/metrics.go
+++ b/gas-oracle/metrics/metrics.go
@@ -1,0 +1,56 @@
+package metrics
+
+import (
+	"github.com/ethereum/go-ethereum/metrics"
+)
+
+var (
+	GasOracleStats struct {
+		// metrics for L2 gas price
+		TxSendCounter           metrics.Counter
+		TxNotSignificantCounter metrics.Counter
+		L2GasPriceGauge         metrics.Gauge
+		TxConfTimer             metrics.Timer
+		TxSendTimer             metrics.Timer
+
+		// metrics for L1 base fee, L1 bas price, da fee
+		// TokenRatioGauge token_ratio = eth_price / mnt_price
+		TokenRatioGauge metrics.Gauge
+		// L1BaseFeeGauge (l1_base_fee + l1_priority_fee) * token_ratio
+		L1BaseFeeGauge metrics.Gauge
+		// FeeScalarGauge value to scale the fee up by
+		FeeScalarGauge metrics.Gauge
+		// DaFeeGauge da_fee shows da gas price
+		DaFeeGauge metrics.Gauge
+		// OverHeadGauge over_head, amortized cost of batch submission per transaction
+		OverHeadGauge metrics.Gauge
+		// L1GasPriceGauge l1_base_fee + l1_priority_fee
+		L1GasPriceGauge metrics.Gauge
+
+		// metrics for gas oracle version
+		// PublishVersionGauge publish_version
+		PublishVersionGauge metrics.Gauge
+	}
+)
+
+func InitAndRegisterStats(r metrics.Registry) {
+	metrics.Enabled = true
+
+	// stats for L2 gas price
+	GasOracleStats.TxSendCounter = metrics.NewRegisteredCounter("tx/send", r)
+	GasOracleStats.TxNotSignificantCounter = metrics.NewRegisteredCounter("tx/not_significant", r)
+	GasOracleStats.L2GasPriceGauge = metrics.NewRegisteredGauge("l2_gas_price", r)
+	GasOracleStats.TxConfTimer = metrics.NewRegisteredTimer("tx/confirmed", r)
+	GasOracleStats.TxSendTimer = metrics.NewRegisteredTimer("tx/send", r)
+
+	// stats for L1 base fee, L1 bas price, da fee
+	GasOracleStats.TokenRatioGauge = metrics.NewRegisteredGauge("token_ratio", r)
+	GasOracleStats.L1BaseFeeGauge = metrics.NewRegisteredGauge("l1_base_fee(l1_gas_price*token_ratio)", r)
+	GasOracleStats.FeeScalarGauge = metrics.NewRegisteredGauge("fee_scalar(*10^6)", r)
+	GasOracleStats.DaFeeGauge = metrics.NewRegisteredGauge("da_fee", r)
+	GasOracleStats.OverHeadGauge = metrics.NewRegisteredGauge("over_head", r)
+	GasOracleStats.L1GasPriceGauge = metrics.NewRegisteredGauge("l1_gas_price(base_fee+priority_fee)", r)
+
+	// stats for gas oracle version
+	GasOracleStats.PublishVersionGauge = metrics.NewRegisteredGauge("publish_version", r)
+}

--- a/gas-oracle/metrics/metrics_test.go
+++ b/gas-oracle/metrics/metrics_test.go
@@ -1,0 +1,31 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitAndRegisterStats(t *testing.T) {
+	InitAndRegisterStats(DefaultRegistry)
+
+	GasOracleStats.L1BaseFeeGauge.Update(100)
+	l1BaseFee := GasOracleStats.L1BaseFeeGauge.Value()
+	require.Equal(t, int64(100), l1BaseFee)
+
+	GasOracleStats.TokenRatioGauge.Update(4000)
+	tokenRatio := GasOracleStats.TokenRatioGauge.Value()
+	require.Equal(t, int64(4000), tokenRatio)
+
+	GasOracleStats.FeeScalarGauge.Update(1500000)
+	feeScalar := GasOracleStats.FeeScalarGauge.Value()
+	require.Equal(t, int64(1500000), feeScalar)
+
+	GasOracleStats.DaFeeGauge.Update(1500000)
+	daFee := GasOracleStats.DaFeeGauge.Value()
+	require.Equal(t, int64(1500000), daFee)
+
+	GasOracleStats.OverHeadGauge.Update(1500000)
+	overHead := GasOracleStats.OverHeadGauge.Value()
+	require.Equal(t, int64(1500000), overHead)
+}

--- a/gas-oracle/oracle/base_fee.go
+++ b/gas-oracle/oracle/base_fee.go
@@ -13,6 +13,7 @@ import (
 
 	bsscore "github.com/mantlenetworkio/mantle/bss-core"
 	"github.com/mantlenetworkio/mantle/gas-oracle/bindings"
+	ometrics "github.com/mantlenetworkio/mantle/gas-oracle/metrics"
 
 	kms "cloud.google.com/go/kms/apiv1"
 	"google.golang.org/api/option"
@@ -77,6 +78,15 @@ func wrapUpdateBaseFee(l1Backend bind.ContractTransactor, l2Backend DeployContra
 		if err != nil {
 			return err
 		}
+		feeScalar, err := contract.Scalar(&bind.CallOpts{
+			Context: context.Background(),
+		})
+		if err != nil {
+			return err
+		}
+		// Update faa scalar metrics
+		ometrics.GasOracleStats.FeeScalarGauge.Update(feeScalar.Int64())
+
 		// NOTE this will return base multiple with coin ratio
 		log.Info("get header in l1 client", "type is", reflect.ValueOf(l1Backend).Type())
 		tip, err := l1Backend.HeaderByNumber(context.Background(), nil)
@@ -113,6 +123,7 @@ func wrapUpdateBaseFee(l1Backend bind.ContractTransactor, l2Backend DeployContra
 			return fmt.Errorf("cannot update base fee: %w", err)
 		}
 		log.Info("L1 base fee transaction already sent", "hash", tx.Hash().Hex(), "baseFee", tip.BaseFee)
+		ometrics.GasOracleStats.L1BaseFeeGauge.Update(tip.BaseFee.Int64())
 
 		if cfg.waitForReceipt {
 			// Wait for the receipt

--- a/gas-oracle/oracle/gas_price_oracle.go
+++ b/gas-oracle/oracle/gas_price_oracle.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/log"
+
 	"github.com/mantlenetworkio/mantle/gas-oracle/bindings"
 	"github.com/mantlenetworkio/mantle/gas-oracle/gasprices"
+	ometrics "github.com/mantlenetworkio/mantle/gas-oracle/metrics"
 	"github.com/mantlenetworkio/mantle/gas-oracle/tokenprice"
 )
 
@@ -78,7 +80,7 @@ func (g *GasPriceOracle) Start() error {
 	if err != nil {
 		return err
 	}
-	gasPriceGauge.Update(int64(price.Uint64()))
+	ometrics.GasOracleStats.L2GasPriceGauge.Update(int64(price.Uint64()))
 
 	log.Info("Starting Gas Price Oracle enableL1BaseFee", "enableL1BaseFee",
 		g.config.enableL1BaseFee, "enableL2GasPrice", g.config.enableL2GasPrice, "enableDaFee", g.config.enableDaFee)

--- a/gas-oracle/oracle/l1_client.go
+++ b/gas-oracle/oracle/l1_client.go
@@ -3,12 +3,14 @@ package oracle
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/log"
 	"math/big"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/log"
+
+	ometrics "github.com/mantlenetworkio/mantle/gas-oracle/metrics"
 	"github.com/mantlenetworkio/mantle/gas-oracle/tokenprice"
 )
 
@@ -50,6 +52,8 @@ func (c *L1Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.
 	bestBaseFee := c.getHistoryBestPrice(tip.Number, tip.BaseFee, 20)
 	tip.BaseFee = new(big.Int).Mul(new(big.Int).Add(bestBaseFee, gasTipCap), big.NewInt(int64(ratio)))
 	log.Info("show base fee context", "bestBaseFee", bestBaseFee, "gasTipCap", gasTipCap, "ratio", ratio)
+	ometrics.GasOracleStats.L1GasPriceGauge.Update(new(big.Int).Add(bestBaseFee, gasTipCap).Int64())
+	ometrics.GasOracleStats.TokenRatioGauge.Update(int64(ratio))
 	return tip, nil
 }
 

--- a/gas-oracle/oracle/overhead.go
+++ b/gas-oracle/oracle/overhead.go
@@ -7,15 +7,17 @@ import (
 	"math/big"
 	"sort"
 
-	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
-	"google.golang.org/api/option"
 
 	bsscore "github.com/mantlenetworkio/mantle/bss-core"
 	"github.com/mantlenetworkio/mantle/gas-oracle/bindings"
+	ometrics "github.com/mantlenetworkio/mantle/gas-oracle/metrics"
+
+	kms "cloud.google.com/go/kms/apiv1"
+	"google.golang.org/api/option"
 )
 
 var jumpTable = make(map[int]*big.Int, 0)
@@ -109,6 +111,7 @@ func wrapUpdateOverhead(l2Backend DeployContractBackend, cfg *Config) (func(*big
 			return fmt.Errorf("cannot update base fee: %w", err)
 		}
 		log.Info("L2 overhead transaction sent", "hash", tx.Hash().Hex(), "old overhead", overhead, "new overhead", newOverheadLevel)
+		ometrics.GasOracleStats.OverHeadGauge.Update(newOverheadLevel.Int64())
 
 		if cfg.waitForReceipt {
 			// Wait for the receipt


### PR DESCRIPTION
# Goals of PR

Core changes:

- Add metrics for gas oracle

Here are stats:

- TokenRatioGauge metrics.Gauge
    - token_ratio = eth_price / mnt_price 
- L1BaseFeeGauge metrics.Gauge
    - (l1_base_fee + l1_priority_fee) * token_ratio
- FeeScalarGauge metrics.Gauge
    - value to scale the fee up by
- DaFeeGauge metrics.Gauge
    - da_fee shows da gas price
- OverHeadGauge metrics.Gauge
    - over_head, amortized cost of batch submission per transaction
- L1GasPriceGauge metrics.Gauge
    - l1_base_fee + l1_priority_fee

Related Issues:

- #1101 
