### PR TITLE
[R4R] Openzepplin-L03-change messager address 

### DIFF
--- a/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
+++ b/packages/contracts/contracts/L1/messaging/L1StandardBridge.sol
@@ -38,8 +38,7 @@ contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
      ***************/
 
     // This contract lives behind a proxy, so the constructor parameters will go unused.
-    constructor() CrossDomainEnabled(address(0)) {}
-
+    constructor() CrossDomainEnabled(0x3900000000000000000000000000000000000000) {}
     /******************
      * Initialization *
      ******************/
@@ -51,7 +50,7 @@ contract L1StandardBridge is IL1StandardBridge, CrossDomainEnabled {
      */
     // slither-disable-next-line external-function
     function initialize(address _l1messenger, address _l2TokenBridge, address _l1MantleAddress) public {
-        require(messenger == address(0), "Contract has already been initialized.");
+        require(messenger == 0x3900000000000000000000000000000000000000, "Contract has already been initialized.");
         messenger = _l1messenger;
         l2TokenBridge = _l2TokenBridge;
         l1MantleAddress = _l1MantleAddress;


### PR DESCRIPTION
# Goals of PR

Core changes:

- fix Openzepplin audit L-03:
change messager init address to 0x3900000000000000000000000000000000000000

Notes:

- Write notes here

Related Issues:

- Link issues here
https://github.com/mantlenetworkio/mantle/issues/1104