### PR TITLE
[gasoracle]feat: optimize how to query and calculate token ratio

### DIFF
--- a/gas-oracle/flags/flags.go
+++ b/gas-oracle/flags/flags.go
@@ -195,6 +195,12 @@ var (
 		Usage:  "token ratio mode",
 		EnvVar: "TOKEN_RATIO_MODE",
 	}
+	TokenPairMNTMode = cli.BoolFlag{
+		Name:     "token-pair-mnt-mode",
+		Usage:    "use mnt price to calculate token ratio",
+		EnvVar:   "TOKEN_PAIR_MNT_MODE",
+		Required: true,
+	}
 	WaitForReceiptFlag = cli.BoolFlag{
 		Name:   "wait-for-receipt",
 		Usage:  "wait for receipts when sending transactions",
@@ -293,6 +299,7 @@ var Flags = []cli.Flag{
 	PriceBackendUniswapURL,
 	TokenPricerUpdateFrequencySecond,
 	TokenRatioMode,
+	TokenPairMNTMode,
 	WaitForReceiptFlag,
 	EnableL1BaseFeeFlag,
 	EnableL1OverheadFlag,

--- a/gas-oracle/gasprices/gas_price_updater_test.go
+++ b/gas-oracle/gasprices/gas_price_updater_test.go
@@ -19,7 +19,7 @@ func makeTestGasPricerAndUpdater(curPrice uint64) (*GasPricer, *GasPriceUpdater,
 	getGasTarget := func() float64 { return gpsTarget }
 	epochLengthSeconds := uint64(10)
 	averageBlockGasLimit := uint64(11000000)
-	tokenPricer := tokenprice.NewClient("", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 0)
+	tokenPricer := tokenprice.NewClient("", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 0, false)
 	// Based on our 10 second epoch, we are targeting 3 blocks per epoch.
 	gasPricer, err := NewGasPricer(curPrice, 1, tokenPricer, getGasTarget, 10)
 	if err != nil {

--- a/gas-oracle/oracle/config.go
+++ b/gas-oracle/oracle/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	PriceBackendUniswapURL           string
 	tokenPricerUpdateFrequencySecond uint64
 	tokenRatioMode                   uint64
+	tokenPairMNTMode                 bool
 	l1BaseFeeSignificanceFactor      float64
 	daFeeSignificanceFactor          float64
 	enableL1BaseFee                  bool
@@ -88,6 +89,7 @@ func NewConfig(ctx *cli.Context) *Config {
 	cfg.PriceBackendUniswapURL = ctx.GlobalString(flags.PriceBackendUniswapURL.Name)
 	cfg.tokenPricerUpdateFrequencySecond = ctx.GlobalUint64(flags.TokenPricerUpdateFrequencySecond.Name)
 	cfg.tokenRatioMode = ctx.GlobalUint64(flags.TokenRatioMode.Name)
+	cfg.tokenPairMNTMode = ctx.GlobalBool(flags.TokenPairMNTMode.Name)
 	cfg.floorPrice = ctx.GlobalUint64(flags.FloorPriceFlag.Name)
 	cfg.l1BaseFeeSignificanceFactor = ctx.GlobalFloat64(flags.L1BaseFeeSignificanceFactorFlag.Name)
 	cfg.daFeeSignificanceFactor = ctx.GlobalFloat64(flags.DaFeeSignificanceFactorFlag.Name)

--- a/gas-oracle/oracle/gas_price_oracle.go
+++ b/gas-oracle/oracle/gas_price_oracle.go
@@ -253,7 +253,8 @@ func (g *GasPriceOracle) Update() error {
 
 // NewGasPriceOracle creates a new GasPriceOracle based on a Config
 func NewGasPriceOracle(cfg *Config) (*GasPriceOracle, error) {
-	tokenPricer := tokenprice.NewClient(cfg.PriceBackendURL, cfg.PriceBackendUniswapURL, cfg.tokenPricerUpdateFrequencySecond, cfg.tokenRatioMode)
+	tokenPricer := tokenprice.NewClient(cfg.PriceBackendURL, cfg.PriceBackendUniswapURL,
+		cfg.tokenPricerUpdateFrequencySecond, cfg.tokenRatioMode, cfg.tokenPairMNTMode)
 	if tokenPricer == nil {
 		return nil, fmt.Errorf("invalid token price client")
 	}

--- a/gas-oracle/oracle/l1_client.go
+++ b/gas-oracle/oracle/l1_client.go
@@ -33,7 +33,7 @@ func NewL1Client(ethereumHttpUrl string, tokenPricer *tokenprice.Client) (*L1Cli
 func (c *L1Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
 	ratio, err := c.tokenPricer.PriceRatioWithMode()
 	if err != nil {
-		ratio = float64(tokenprice.DefaultTokenRatio)
+		ratio = tokenprice.DefaultTokenRatio
 	}
 	tip, err := c.Client.HeaderByNumber(ctx, number)
 	if err != nil {

--- a/gas-oracle/tokenprice/tokenprice.go
+++ b/gas-oracle/tokenprice/tokenprice.go
@@ -104,30 +104,31 @@ func (c *Client) PriceRatioWithMode() (float64, error) {
 	}
 
 	// Todo query token prices concurrent
+	var mntPrices, ethPrices []float64
 	var mntPrice1, ethPrice1, mntPrice2, ethPrice2, mntPrice3, ethPrice3 float64
 	var err1, err2, err3 error
 	// get token price from oracle1(dex)
-	if mntPrice1, ethPrice1, err1 = c.getTokenPricesFromUniswap(); err1 != nil {
-		mntPrice1 = DefaultMNTPrice
-		ethPrice1 = DefaultETHPrice
+	if mntPrice1, ethPrice1, err1 = c.getTokenPricesFromUniswap(); err1 == nil {
+		mntPrices = append(mntPrices, mntPrice1)
+		ethPrices = append(ethPrices, ethPrice1)
 	}
 
 	// get token price from oracle2(cex)
-	if mntPrice2, ethPrice2, err2 = c.getTokenPricesFromCex(); err2 != nil {
-		mntPrice2 = DefaultMNTPrice
-		ethPrice2 = DefaultETHPrice
+	if mntPrice2, ethPrice2, err2 = c.getTokenPricesFromCex(); err2 == nil {
+		mntPrices = append(mntPrices, mntPrice2)
+		ethPrices = append(ethPrices, ethPrice2)
 	}
 
 	// get token price from oracle3(cex)
 	// Todo add a third oracle to query prices
 	if mntPrice3, ethPrice3, err3 = c.getTokenPricesFromCex(); err3 != nil {
-		mntPrice3 = DefaultMNTPrice
-		ethPrice3 = DefaultETHPrice
+		mntPrices = append(mntPrices, mntPrice3)
+		ethPrices = append(ethPrices, ethPrice3)
 	}
 
 	// median price for eth & mnt
-	medianMNTPrice := getMedian(mntPrice1, mntPrice2, mntPrice3)
-	medianETHPrice := getMedian(ethPrice1, ethPrice2, ethPrice3)
+	medianMNTPrice := getMedian(mntPrices)
+	medianETHPrice := getMedian(ethPrices)
 
 	// determine mnt_price, eth_price
 	mntPrice := c.determineMNTPrice(medianMNTPrice)
@@ -207,7 +208,7 @@ func determineTokenPairForMNT(tokenPairMNTMode bool) string {
 	}
 }
 
-func getMedian(nums ...float64) float64 {
+func getMedian(nums []float64) float64 {
 	sort.Float64s(nums)
 	return nums[len(nums)/2]
 }

--- a/gas-oracle/tokenprice/tokenprice.go
+++ b/gas-oracle/tokenprice/tokenprice.go
@@ -3,7 +3,7 @@ package tokenprice
 import (
 	"errors"
 	"fmt"
-	"math/big"
+	"sort"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -13,23 +13,15 @@ type TokenRatioMode uint64
 
 // Client is an HTTP based TokenPriceClient
 type Client struct {
-	client              *resty.Client
-	uniswapQuoterClient *uniswapClient
-	frequency           time.Duration
-	lastRatio           float64
-	lastEthPrice        float64
-	lastUpdate          time.Time
-	tokenRatioMode      TokenRatioMode
-}
-
-type TokenPrice struct {
-	Symbol string `json:"symbol"`
-	Price  string `json:"price"`
-}
-
-type Result struct {
-	RetCode int
-	Result  TokenPrice
+	client               *resty.Client
+	uniswapQuoterClient  *uniswapClient
+	frequency            time.Duration
+	lastRatio            float64
+	lastEthPrice         float64
+	lastMntPrice         float64
+	lastUpdate           time.Time
+	tokenRatioMode       TokenRatioMode
+	tokenPairForMNTPrice string
 }
 
 var (
@@ -38,23 +30,23 @@ var (
 	// DefaultTokenRatio is eth_price / mnt_price, 4000 = $1800/$0.45
 	DefaultTokenRatio = float64(4000)
 	// TokenRatioMax token_ratio upper bounds
-	TokenRatioMax = float64(10000)
+	TokenRatioMax = float64(100000)
 	// TokenRatioMin token_ratio lower bounds
-	TokenRatioMin = float64(500)
+	TokenRatioMin = float64(100)
 
 	// DefaultETHPrice is default eth_price
 	// If SwitchOneDollarTokenRatio valid, use DefaultETHPrice to set token_ratio to make mnt_price is 1$
-	DefaultETHPrice = big.NewFloat(1800)
+	DefaultETHPrice = float64(1800)
 	// ETHPriceMax eth_price upper bounds
-	ETHPriceMax = big.NewFloat(20000)
+	ETHPriceMax = float64(20000)
 	// ETHPriceMin eth_price lower bounds
-	ETHPriceMin = big.NewFloat(100)
+	ETHPriceMin = float64(100)
 
-	DefaultMNTPrice = big.NewFloat(0.45)
+	DefaultMNTPrice = 0.45
 	// MNTPriceMax mnt_price upper bounds
-	MNTPriceMax = big.NewFloat(10)
+	MNTPriceMax = float64(10)
 	// MNTPriceMin mnt_price lower bounds
-	MNTPriceMin = big.NewFloat(0.2)
+	MNTPriceMin = 0.2
 
 	// RealTokenRatioMode use eth_price / mnt_price to set token_ratio
 	RealTokenRatioMode = TokenRatioMode(0)
@@ -62,10 +54,19 @@ var (
 	OneDollarTokenRatioMode = TokenRatioMode(1)
 	// DefaultTokenRatioMode use DefaultTokenRatio to set token_ratio
 	DefaultTokenRatioMode = TokenRatioMode(2)
+
+	// token pairs, used to query token pairs price
+	// ETHUSDT used to query eth/usdt price
+	ETHUSDT = "ETHUSDT"
+	// BITUSDT used to query bit/usdt price
+	BITUSDT = "BITUSDT"
+	// MNTUSDT used to query mnt/usdt price
+	MNTUSDT = "MNTUSDT"
 )
 
 // NewClient create a new Client given a remote HTTP url, update frequency and different mode_switch for token ratio
-func NewClient(url, uniswapURL string, frequency uint64, tokenRatioMode uint64) *Client {
+// tokenPairMNTMode(true/false) to choose if mnt_price is in production
+func NewClient(url, uniswapURL string, frequency uint64, tokenRatioMode uint64, tokenPairMNTMode bool) *Client {
 	client := resty.New()
 	client.SetHostURL(url)
 	client.OnAfterResponse(func(c *resty.Client, r *resty.Response) error {
@@ -78,16 +79,22 @@ func NewClient(url, uniswapURL string, frequency uint64, tokenRatioMode uint64) 
 		return nil
 	})
 
-	uniswapQuoterClient, err := newUniswapClient(uniswapURL)
+	uniswapQuoterClient, err := newUniswapClient(uniswapURL, tokenPairMNTMode)
 	if err != nil {
 		return nil
 	}
 
+	tokenPairForMNTPrice := determineTokenPairForMNT(tokenPairMNTMode)
+
 	return &Client{
-		client:              client,
-		uniswapQuoterClient: uniswapQuoterClient,
-		frequency:           time.Duration(frequency) * time.Second,
-		tokenRatioMode:      TokenRatioMode(tokenRatioMode),
+		client:               client,
+		uniswapQuoterClient:  uniswapQuoterClient,
+		frequency:            time.Duration(frequency) * time.Second,
+		lastRatio:            DefaultTokenRatio,
+		lastEthPrice:         DefaultETHPrice,
+		lastMntPrice:         DefaultMNTPrice,
+		tokenRatioMode:       TokenRatioMode(tokenRatioMode),
+		tokenPairForMNTPrice: tokenPairForMNTPrice,
 	}
 }
 
@@ -97,25 +104,37 @@ func (c *Client) PriceRatioWithMode() (float64, error) {
 	}
 
 	// Todo query token prices concurrent
-	var ratio, ethPrice float64
-	var errDex error
-	// get token price from dex
-	if ratio, ethPrice, errDex = c.getTokenPricesFromUniswap(); errDex != nil {
-		ratio = DefaultTokenRatio
-		ethPrice, _ = DefaultETHPrice.Float64()
+	var mntPrice1, ethPrice1, mntPrice2, ethPrice2, mntPrice3, ethPrice3 float64
+	var err1, err2, err3 error
+	// get token price from oracle1(dex)
+	if mntPrice1, ethPrice1, err1 = c.getTokenPricesFromUniswap(); err1 != nil {
+		mntPrice1 = DefaultMNTPrice
+		ethPrice1 = DefaultETHPrice
 	}
 
-	// get token price from cex
-	// if both dex and cex return token prices correctly, token price from cex will be used
-	// if cex failed, token price from dex will be used
-	// if both failed, default value will be used
-	if ratioCex, ethPriceCex, errCex := c.priceRatio(); errCex != nil && errDex != nil {
-		ratio = DefaultTokenRatio
-		ethPrice, _ = DefaultETHPrice.Float64()
-	} else if errCex == nil {
-		ratio = ratioCex
-		ethPrice = ethPriceCex
+	// get token price from oracle2(cex)
+	if mntPrice2, ethPrice2, err2 = c.getTokenPricesFromCex(); err2 != nil {
+		mntPrice2 = DefaultMNTPrice
+		ethPrice2 = DefaultETHPrice
 	}
+
+	// get token price from oracle3(cex)
+	// Todo add a third oracle to query prices
+	if mntPrice3, ethPrice3, err3 = c.getTokenPricesFromCex(); err3 != nil {
+		mntPrice3 = DefaultMNTPrice
+		ethPrice3 = DefaultETHPrice
+	}
+
+	// median price for eth & mnt
+	medianMNTPrice := getMedian(mntPrice1, mntPrice2, mntPrice3)
+	medianETHPrice := getMedian(ethPrice1, ethPrice2, ethPrice3)
+
+	// determine mnt_price, eth_price
+	mntPrice := c.determineMNTPrice(medianMNTPrice)
+	ethPrice := c.determineETHPrice(medianETHPrice)
+
+	// calculate ratio
+	ratio := c.determineTokenRatio(mntPrice, ethPrice)
 
 	switch c.tokenRatioMode {
 	case DefaultTokenRatioMode:
@@ -135,68 +154,74 @@ func (c *Client) PriceRatioWithMode() (float64, error) {
 	return ratio, nil
 }
 
-func (c *Client) priceRatio() (float64, float64, error) {
-	ethPrice, err := c.query("ETHUSDT")
+func (c *Client) getTokenPricesFromCex() (float64, float64, error) {
+	ethPrice, err := c.queryV5(ETHUSDT)
 	if err != nil {
 		return 0, 0, err
 	}
-	mntPrice, err := c.query("BITUSDT")
+	mntPrice, err := c.queryV5(c.tokenPairForMNTPrice)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	ethPrice = determineETHPrice(ethPrice)
-	mntPrice = determineMNTPrice(mntPrice)
-
-	ratio, _ := new(big.Float).Quo(ethPrice, mntPrice).Float64()
-	ratio = determineTokenRatio(ratio)
-
-	ethPriceFloat64, _ := ethPrice.Float64()
-
-	return ratio, ethPriceFloat64, nil
+	return mntPrice, ethPrice, nil
 }
 
-func (c *Client) query(symbol string) (*big.Float, error) {
-	response, err := c.client.R().
-		SetResult(&Result{}).
-		SetQueryParams(map[string]string{
-			"symbol": symbol,
-		}).
-		Get("/spot/quote/v1/ticker/price")
-	if err != nil {
-		return nil, fmt.Errorf("cannot fetch token price result: %w", err)
-	}
-	result, ok := response.Result().(*Result)
-	if !ok {
-		return nil, fmt.Errorf("cannot parse result")
-	}
-	if result.Result.Price == "" {
-		return nil, fmt.Errorf("empty price")
-	}
-	bigPrice, _ := big.NewFloat(0).SetString(result.Result.Price)
-	return bigPrice, nil
-}
-
-func determineMNTPrice(price *big.Float) *big.Float {
-	if price.Cmp(MNTPriceMax) == 1 || price.Cmp(MNTPriceMin) == -1 {
-		return DefaultMNTPrice
+func (c *Client) determineMNTPrice(price float64) float64 {
+	if price > MNTPriceMax || price < MNTPriceMin {
+		return c.lastMntPrice
 	}
 
 	return price
 }
 
-func determineETHPrice(price *big.Float) *big.Float {
-	if price.Cmp(ETHPriceMax) == 1 || price.Cmp(ETHPriceMin) == -1 {
-		return DefaultETHPrice
+func (c *Client) determineETHPrice(price float64) float64 {
+	if price > ETHPriceMax || price < (ETHPriceMin) {
+		return c.lastEthPrice
 	}
 
 	return price
 }
 
-func determineTokenRatio(ratio float64) float64 {
-	if ratio < TokenRatioMin || ratio > TokenRatioMax {
-		return DefaultTokenRatio
+func (c *Client) determineTokenRatio(mntPrice, ethPrice float64) float64 {
+	// calculate [tokenRatioMin, tokenRatioMax]
+	tokenRatioMin := getMax(c.lastRatio*0.95, TokenRatioMin)
+	tokenRatioMax := getMin(c.lastRatio*1.05, TokenRatioMax)
+
+	ratio := ethPrice / mntPrice
+	if ratio <= tokenRatioMin {
+		return tokenRatioMin
+	}
+	if ratio >= tokenRatioMax {
+		return tokenRatioMax
 	}
 
 	return ratio
+}
+
+func determineTokenPairForMNT(tokenPairMNTMode bool) string {
+	if tokenPairMNTMode {
+		return MNTUSDT
+	} else {
+		return BITUSDT
+	}
+}
+
+func getMedian(nums ...float64) float64 {
+	sort.Float64s(nums)
+	return nums[len(nums)/2]
+}
+
+func getMax(a, b float64) float64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func getMin(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/gas-oracle/tokenprice/tokenprice.go
+++ b/gas-oracle/tokenprice/tokenprice.go
@@ -38,15 +38,15 @@ var (
 	// If SwitchOneDollarTokenRatio valid, use DefaultETHPrice to set token_ratio to make mnt_price is 1$
 	DefaultETHPrice = float64(1800)
 	// ETHPriceMax eth_price upper bounds
-	ETHPriceMax = float64(20000)
+	ETHPriceMax = float64(1000000)
 	// ETHPriceMin eth_price lower bounds
 	ETHPriceMin = float64(100)
 
 	DefaultMNTPrice = 0.45
 	// MNTPriceMax mnt_price upper bounds
-	MNTPriceMax = float64(10)
+	MNTPriceMax = float64(100)
 	// MNTPriceMin mnt_price lower bounds
-	MNTPriceMin = 0.2
+	MNTPriceMin = 0.01
 
 	// RealTokenRatioMode use eth_price / mnt_price to set token_ratio
 	RealTokenRatioMode = TokenRatioMode(0)

--- a/gas-oracle/tokenprice/tokenprice_test.go
+++ b/gas-oracle/tokenprice/tokenprice_test.go
@@ -120,19 +120,22 @@ func TestGetTokenPriceWithMNT(t *testing.T) {
 }
 
 func Test_getMedian(t *testing.T) {
-	result := getMedian(1.1, 2.1)
+	result := getMedian([]float64{1.1})
+	require.Equal(t, 1.1, result)
+
+	result = getMedian([]float64{1.1, 2.1})
 	require.Equal(t, 2.1, result)
 
-	result = getMedian(2.1, 1.1)
+	result = getMedian([]float64{2.1, 1.1})
 	require.Equal(t, 2.1, result)
 
-	result = getMedian(1.1, 2.1, 3.1)
+	result = getMedian([]float64{1.1, 2.1, 3.1})
 	require.Equal(t, 2.1, result)
 
-	result = getMedian(1.1, 3.1, 2.1)
+	result = getMedian([]float64{1.1, 3.1, 2.1})
 	require.Equal(t, 2.1, result)
 
-	result = getMedian(1.1, 3.1, 2.1, 4.1)
+	result = getMedian([]float64{1.1, 3.1, 2.1, 4.1})
 	require.Equal(t, 3.1, result)
 }
 

--- a/gas-oracle/tokenprice/tokenprice_test.go
+++ b/gas-oracle/tokenprice/tokenprice_test.go
@@ -17,8 +17,7 @@ func TestGetTokenPrice(t *testing.T) {
 	t.Logf("BIT price:%v", bitPrice)
 
 	t.Logf("ratio:%v", ethPrice/bitPrice)
-	bitPrice, ethPrice, err = tokenPricer.getTokenPricesFromCex()
-	require.NoError(t, err)
+	bitPrice, ethPrice = tokenPricer.getTokenPricesFromCex()
 	t.Logf("ETH price:%v", ethPrice)
 	t.Logf("BIT price:%v", bitPrice)
 	t.Logf("ratio:%v", ethPrice/bitPrice)
@@ -55,8 +54,7 @@ func TestGetTokenPriceWithOneDollarTokenRatioMode(t *testing.T) {
 func TestGetTokenPriceWithOneDollarTokenRatioMode2(t *testing.T) {
 	tokenPricer := NewClient("", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 1, false)
 
-	_, ethPrice, err := tokenPricer.getTokenPricesFromUniswap()
-	require.NoError(t, err)
+	_, ethPrice := tokenPricer.getTokenPricesFromUniswap()
 	t.Logf("ETH price:%v", ethPrice)
 
 	ratio, err := tokenPricer.PriceRatioWithMode()
@@ -120,10 +118,13 @@ func TestGetTokenPriceWithMNT(t *testing.T) {
 }
 
 func Test_getMedian(t *testing.T) {
-	result := getMedian([]float64{1.1})
+	result := getMedian([]float64{0, 0, 0})
+	require.Equal(t, float64(0), result)
+
+	result = getMedian([]float64{1.1, 0, 0})
 	require.Equal(t, 1.1, result)
 
-	result = getMedian([]float64{1.1, 2.1})
+	result = getMedian([]float64{1.1, 2.1, 0})
 	require.Equal(t, 2.1, result)
 
 	result = getMedian([]float64{2.1, 1.1})

--- a/gas-oracle/tokenprice/tokenprice_test.go
+++ b/gas-oracle/tokenprice/tokenprice_test.go
@@ -1,14 +1,13 @@
 package tokenprice
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetTokenPrice(t *testing.T) {
-	tokenPricer := NewClient("https://api.bybit.com", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 0)
+	tokenPricer := NewClient("https://api.bybit.com", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 0, false)
 	ethPrice, err := tokenPricer.query("ETHUSDT")
 	require.NoError(t, err)
 	t.Logf("ETH price:%v", ethPrice)
@@ -17,22 +16,24 @@ func TestGetTokenPrice(t *testing.T) {
 	require.NoError(t, err)
 	t.Logf("BIT price:%v", bitPrice)
 
-	t.Log(ethPrice.Quo(ethPrice, bitPrice))
-	ratio, _, err := tokenPricer.priceRatio()
+	t.Logf("ratio:%v", ethPrice/bitPrice)
+	bitPrice, ethPrice, err = tokenPricer.getTokenPricesFromCex()
 	require.NoError(t, err)
-	t.Logf("ratio:%v", ratio)
+	t.Logf("ETH price:%v", ethPrice)
+	t.Logf("BIT price:%v", bitPrice)
+	t.Logf("ratio:%v", ethPrice/bitPrice)
 
-	ratioFromUniswap, err := tokenPricer.getTokenPriceFromUniswap(wETHAddress, bitTokenAddress, bitTokenDecimals)
+	eth2bitPrice, err := tokenPricer.getTokenPriceFromUniswap(wETHAddress, bitTokenAddress, bitTokenDecimals)
 	require.NoError(t, err)
-	t.Logf("ETH/BIT:%v", ratioFromUniswap)
+	t.Logf("ETH/BIT:%v", eth2bitPrice)
 
-	ratioFromUniswap, err = tokenPricer.getTokenPriceFromUniswap(wETHAddress, usdtAddress, usdtDecimals)
+	ethPrice, err = tokenPricer.getTokenPriceFromUniswap(wETHAddress, usdtAddress, usdtDecimals)
 	require.NoError(t, err)
-	t.Logf("ETH/USDT:%v", ratioFromUniswap)
+	t.Logf("ETH/USDT:%v", ethPrice)
 }
 
 func TestGetTokenPriceWithRealTokenRatioMode(t *testing.T) {
-	tokenPricer := NewClient("https://api.bybit.com", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 0)
+	tokenPricer := NewClient("https://api.bybit.com", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 0, false)
 
 	ratio, err := tokenPricer.PriceRatioWithMode()
 	require.NoError(t, err)
@@ -40,7 +41,7 @@ func TestGetTokenPriceWithRealTokenRatioMode(t *testing.T) {
 }
 
 func TestGetTokenPriceWithOneDollarTokenRatioMode(t *testing.T) {
-	tokenPricer := NewClient("https://api.bybit.com", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 1)
+	tokenPricer := NewClient("https://api.bybit.com", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 1, false)
 
 	ethPrice, err := tokenPricer.query("ETHUSDT")
 	require.NoError(t, err)
@@ -52,7 +53,7 @@ func TestGetTokenPriceWithOneDollarTokenRatioMode(t *testing.T) {
 }
 
 func TestGetTokenPriceWithOneDollarTokenRatioMode2(t *testing.T) {
-	tokenPricer := NewClient("", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 1)
+	tokenPricer := NewClient("", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 1, false)
 
 	_, ethPrice, err := tokenPricer.getTokenPricesFromUniswap()
 	require.NoError(t, err)
@@ -64,19 +65,83 @@ func TestGetTokenPriceWithOneDollarTokenRatioMode2(t *testing.T) {
 }
 
 func TestGetTokenPriceWithOneDollarTokenRatioMode3(t *testing.T) {
-	tokenPricer := NewClient("", "https://mainnet.infura.io/v3", 3, 1)
+	tokenPricer := NewClient("", "https://mainnet.infura.io/v3", 3, 1, false)
 
 	ratio, err := tokenPricer.PriceRatioWithMode()
 	require.NoError(t, err)
-	require.Equal(t, DefaultETHPrice, big.NewFloat(ratio))
+	require.Equal(t, DefaultETHPrice, ratio)
 	t.Logf("ratio:%v", ratio)
 }
 
 func TestGetTokenPriceWithDefaultTokenRatioMode(t *testing.T) {
-	tokenPricer := NewClient("https://api.bybit.com", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 2)
+	tokenPricer := NewClient("https://api.bybit.com", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 2, false)
 
 	ratio, err := tokenPricer.PriceRatioWithMode()
 	require.NoError(t, err)
 	require.Equal(t, DefaultTokenRatio, ratio)
 	t.Logf("ratio:%v", ratio)
+}
+
+func TestGetTokenPriceWithNoSource(t *testing.T) {
+	// source url are both invalid, so can not access correct prices
+	tokenPricer := NewClient("https://api.bybit.co", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c232", 3, 0, false)
+
+	ratio, err := tokenPricer.PriceRatioWithMode()
+	require.NoError(t, err)
+	require.Equal(t, DefaultTokenRatio, ratio)
+	t.Logf("ratio:%v", ratio)
+}
+
+func TestGetTokenPriceWithOnlySource1(t *testing.T) {
+	// uniswapURL is invalid, so can not access correct prices
+	tokenPricer := NewClient("https://api.bybit.com", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c232", 3, 0, false)
+
+	ratio, err := tokenPricer.PriceRatioWithMode()
+	require.NoError(t, err)
+	t.Logf("ratio:%v", ratio)
+}
+
+func TestGetTokenPriceWithOnlySource2(t *testing.T) {
+	// only uniswapURL is valid
+	tokenPricer := NewClient("https://api.bybit.co", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 0, false)
+
+	ratio, err := tokenPricer.PriceRatioWithMode()
+	require.NoError(t, err)
+	t.Logf("ratio:%v", ratio)
+}
+
+func TestGetTokenPriceWithMNT(t *testing.T) {
+	// only uniswapURL is valid
+	tokenPricer := NewClient("https://api.bybit.com", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 0, true)
+
+	ratio, err := tokenPricer.PriceRatioWithMode()
+	require.NoError(t, err)
+	t.Logf("ratio:%v", ratio)
+}
+
+func Test_getMedian(t *testing.T) {
+	result := getMedian(1.1, 2.1)
+	require.Equal(t, 2.1, result)
+
+	result = getMedian(2.1, 1.1)
+	require.Equal(t, 2.1, result)
+
+	result = getMedian(1.1, 2.1, 3.1)
+	require.Equal(t, 2.1, result)
+
+	result = getMedian(1.1, 3.1, 2.1)
+	require.Equal(t, 2.1, result)
+
+	result = getMedian(1.1, 3.1, 2.1, 4.1)
+	require.Equal(t, 3.1, result)
+}
+
+func Test_getMax(t *testing.T) {
+	result := getMax(1.1, 2.1)
+	require.Equal(t, 2.1, result)
+}
+
+func Test_getMin(t *testing.T) {
+	result := getMin(1.1, 2.1)
+	require.Equal(t, 1.1, result)
 }

--- a/gas-oracle/tokenprice/tokenprice_uniswap.go
+++ b/gas-oracle/tokenprice/tokenprice_uniswap.go
@@ -62,20 +62,20 @@ func newUniswapClient(uniswapURL string, tokenPairMNTMode bool) (*uniswapClient,
 	return quoterClient, nil
 }
 
-func (c *Client) getTokenPricesFromUniswap() (float64, float64, error) {
+func (c *Client) getTokenPricesFromUniswap() (float64, float64) {
 
 	eth2mntPrice, err := c.getTokenPriceFromUniswap(c.uniswapQuoterClient.ethAddress,
 		c.uniswapQuoterClient.mntAddress, c.uniswapQuoterClient.mntDecimals)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0
 	}
 	eth2usdtPrice, err := c.getTokenPriceFromUniswap(c.uniswapQuoterClient.ethAddress,
 		c.uniswapQuoterClient.usdttAddress, c.uniswapQuoterClient.usdtDecimals)
 	if err != nil {
-		return 0, 0, err
+		return 0, eth2mntPrice
 	}
 
-	return eth2usdtPrice / eth2mntPrice, eth2usdtPrice, nil
+	return eth2usdtPrice / eth2mntPrice, eth2usdtPrice
 }
 
 // getTokenPriceFromUniswap estimate to execute swapping from_token to to_token to get token price

--- a/gas-oracle/tokenprice/tokenprice_uniswap.go
+++ b/gas-oracle/tokenprice/tokenprice_uniswap.go
@@ -17,18 +17,25 @@ var (
 	wETHAddress     = common.HexToAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
 	bitTokenAddress = common.HexToAddress("0x1A4b46696b2bB4794Eb3D4c26f1c55F9170fa4C5")
 	usdtAddress     = common.HexToAddress("0xdAC17F958D2ee523a2206206994597C13D831ec7")
+	mntTokenAddress = common.HexToAddress("0x3c3a81e81dc49A522A592e7622A7E711c06bf354")
 
-	bitTokenDecimals = floatStringToBigInt("1", 18)
-	usdtDecimals     = floatStringToBigInt("1", 6)
+	bitTokenDecimals = floatStringToBigFloat("1", 18)
+	mntTokenDecimals = floatStringToBigFloat("1", 18)
+	usdtDecimals     = floatStringToBigFloat("1", 6)
 
 	ContractV3Quoter = common.HexToAddress("0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6")
 )
 
 type uniswapClient struct {
 	uniswapV3Quoter *bindings.Uniswapv3Quoter
+	ethAddress      common.Address
+	mntAddress      common.Address
+	usdttAddress    common.Address
+	mntDecimals     *big.Float
+	usdtDecimals    *big.Float
 }
 
-func newUniswapClient(uniswapURL string) (*uniswapClient, error) {
+func newUniswapClient(uniswapURL string, tokenPairMNTMode bool) (*uniswapClient, error) {
 	l1Client, err := ethclient.Dial(uniswapURL)
 	if err != nil {
 		return nil, err
@@ -39,30 +46,40 @@ func newUniswapClient(uniswapURL string) (*uniswapClient, error) {
 		return nil, err
 	}
 
-	return &uniswapClient{
+	quoterClient := &uniswapClient{
 		uniswapV3Quoter: uniswapV3Quoter,
-	}, nil
+		ethAddress:      wETHAddress,
+		mntAddress:      mntTokenAddress,
+		usdttAddress:    usdtAddress,
+		mntDecimals:     mntTokenDecimals,
+		usdtDecimals:    usdtDecimals,
+	}
+
+	if !tokenPairMNTMode {
+		quoterClient.mntAddress = bitTokenAddress
+	}
+
+	return quoterClient, nil
 }
 
 func (c *Client) getTokenPricesFromUniswap() (float64, float64, error) {
 
-	eth2bitPrice, err := c.getTokenPriceFromUniswap(wETHAddress, bitTokenAddress, bitTokenDecimals)
+	eth2mntPrice, err := c.getTokenPriceFromUniswap(c.uniswapQuoterClient.ethAddress,
+		c.uniswapQuoterClient.mntAddress, c.uniswapQuoterClient.mntDecimals)
 	if err != nil {
 		return 0, 0, err
 	}
-	eth2usdtPrice, err := c.getTokenPriceFromUniswap(wETHAddress, usdtAddress, usdtDecimals)
+	eth2usdtPrice, err := c.getTokenPriceFromUniswap(c.uniswapQuoterClient.ethAddress,
+		c.uniswapQuoterClient.usdttAddress, c.uniswapQuoterClient.usdtDecimals)
 	if err != nil {
 		return 0, 0, err
 	}
 
-	tokenRatio := determineTokenRatio(float64(eth2bitPrice))
-	ethPrice, _ := determineETHPrice(big.NewFloat(float64(eth2usdtPrice))).Float64()
-
-	return tokenRatio, ethPrice, nil
+	return eth2usdtPrice / eth2mntPrice, eth2usdtPrice, nil
 }
 
 // getTokenPriceFromUniswap estimate to execute swapping from_token to to_token to get token price
-func (c *Client) getTokenPriceFromUniswap(fromToken, toToken common.Address, decimals *big.Int) (int64, error) {
+func (c *Client) getTokenPriceFromUniswap(fromToken, toToken common.Address, decimals *big.Float) (float64, error) {
 	fee := big.NewInt(3000)
 	fromAmount := floatStringToBigInt("1.00", 18)
 	sqrtPriceLimitX96 := big.NewInt(0)
@@ -75,11 +92,19 @@ func (c *Client) getTokenPriceFromUniswap(fromToken, toToken common.Address, dec
 		return 0, err
 	}
 
-	return new(big.Int).Div(out[0].(*big.Int), decimals).Int64(), nil
+	resultBigFloat := new(big.Float).SetInt(out[0].(*big.Int))
+	result, _ := new(big.Float).Quo(resultBigFloat, decimals).Float64()
+	return result, nil
 }
 
 func floatStringToBigInt(amount string, decimals int) *big.Int {
 	fAmount, _ := new(big.Float).SetString(amount)
 	fi, _ := new(big.Float).Mul(fAmount, big.NewFloat(math.Pow10(decimals))).Int(nil)
+	return fi
+}
+
+func floatStringToBigFloat(amount string, decimals int) *big.Float {
+	fAmount, _ := new(big.Float).SetString(amount)
+	fi := new(big.Float).Mul(fAmount, big.NewFloat(math.Pow10(decimals)))
 	return fi
 }

--- a/gas-oracle/tokenprice/tokenprice_uniswap_test.go
+++ b/gas-oracle/tokenprice/tokenprice_uniswap_test.go
@@ -1,0 +1,18 @@
+package tokenprice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getTokenPriceFromUniswap(t *testing.T) {
+	tokenPricer := NewClient("", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 0, false)
+	ethPrice, err := tokenPricer.getTokenPriceFromUniswap(wETHAddress, usdtAddress, usdtDecimals)
+	require.NoError(t, err)
+	t.Logf("ETH price:%v", ethPrice)
+
+	eth2bitPrice, err := tokenPricer.getTokenPriceFromUniswap(wETHAddress, bitTokenAddress, bitTokenDecimals)
+	require.NoError(t, err)
+	t.Logf("BIT price:%v", ethPrice/eth2bitPrice)
+}

--- a/gas-oracle/tokenprice/tokenprice_v1.go
+++ b/gas-oracle/tokenprice/tokenprice_v1.go
@@ -1,0 +1,38 @@
+package tokenprice
+
+import (
+	"fmt"
+	"math/big"
+)
+
+type TokenPrice struct {
+	Symbol string `json:"symbol"`
+	Price  string `json:"price"`
+}
+
+type Result struct {
+	RetCode int
+	Result  TokenPrice
+}
+
+func (c *Client) query(symbol string) (float64, error) {
+	response, err := c.client.R().
+		SetResult(&Result{}).
+		SetQueryParams(map[string]string{
+			"symbol": symbol,
+		}).
+		Get("/spot/quote/v1/ticker/price")
+	if err != nil {
+		return 0, fmt.Errorf("cannot fetch token price result: %w", err)
+	}
+	result, ok := response.Result().(*Result)
+	if !ok {
+		return 0, fmt.Errorf("cannot parse result")
+	}
+	if result.Result.Price == "" {
+		return 0, fmt.Errorf("empty price")
+	}
+	priceBigFloat, _ := big.NewFloat(0).SetString(result.Result.Price)
+	priceFloat64, _ := priceBigFloat.Float64()
+	return priceFloat64, nil
+}

--- a/gas-oracle/tokenprice/tokenprice_v1_test.go
+++ b/gas-oracle/tokenprice/tokenprice_v1_test.go
@@ -1,0 +1,18 @@
+package tokenprice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTokenPriceV1(t *testing.T) {
+	tokenPricer := NewClient("https://api.bybit.com", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 0, false)
+	ethPrice, err := tokenPricer.query(ETHUSDT)
+	require.NoError(t, err)
+	t.Logf("ETH price:%v", ethPrice)
+
+	bitPrice, err := tokenPricer.query(BITUSDT)
+	require.NoError(t, err)
+	t.Logf("BIT price:%v", bitPrice)
+}

--- a/gas-oracle/tokenprice/tokenprice_v5.go
+++ b/gas-oracle/tokenprice/tokenprice_v5.go
@@ -1,0 +1,54 @@
+package tokenprice
+
+import (
+	"fmt"
+	"math/big"
+)
+
+var (
+	noHTTPError = 0
+)
+
+type Response struct {
+	RetCode     int         `json:"retCode"`
+	RetMsg      string      `json:"retMsg"`
+	PriceResult PriceResult `json:"result"`
+	RetExtInfo  struct{}    `json:"retExtInfo"`
+	Time        int64       `json:"time"`
+}
+
+type PriceResult struct {
+	Category string `json:"category"`
+	List     []Item `json:"list"`
+}
+
+type Item struct {
+	Symbol     string `json:"symbol"`
+	LastPrice  string `json:"lastPrice"`
+	IndexPrice string `json:"indexPrice"`
+}
+
+func (c *Client) queryV5(symbol string) (float64, error) {
+	response, err := c.client.R().
+		SetResult(&Response{}).
+		SetQueryParams(map[string]string{
+			"symbol": symbol,
+		}).
+		Get("v5/market/tickers?category=linear&")
+	if err != nil {
+		return 0, fmt.Errorf("cannot fetch token price result: %w", err)
+	}
+	result, ok := response.Result().(*Response)
+	if !ok {
+		return 0, fmt.Errorf("cannot parse result")
+	}
+	if result.RetCode != noHTTPError {
+		return 0, fmt.Errorf("query error")
+	}
+	if len(result.PriceResult.List) == 0 {
+		return 0, fmt.Errorf("empty price in result")
+	}
+	priceBigFloat, _ := big.NewFloat(0).SetString(result.PriceResult.List[0].IndexPrice)
+	priceFloat64, _ := priceBigFloat.Float64()
+	return priceFloat64, nil
+}

--- a/gas-oracle/tokenprice/tokenprice_v5_test.go
+++ b/gas-oracle/tokenprice/tokenprice_v5_test.go
@@ -1,0 +1,18 @@
+package tokenprice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTokenPriceV5(t *testing.T) {
+	tokenPricer := NewClient("https://api.bybit.com", "https://mainnet.infura.io/v3/4f4692085f1340c2a645ae04d36c2321", 3, 0, false)
+	ethPrice, err := tokenPricer.queryV5(ETHUSDT)
+	require.NoError(t, err)
+	t.Logf("ETH price:%v", ethPrice)
+
+	bitPrice, err := tokenPricer.queryV5(BITUSDT)
+	require.NoError(t, err)
+	t.Logf("BIT price:%v", bitPrice)
+}


### PR DESCRIPTION
# Goals of PR

Core changes:

- calculate eth_price, mnt_price from multi oracle, use `median` value of them
    - use `index price` from cex instead of latest price
- add bounds check for eth_price, mnt_price and token_radio
    - token_ratio = eth_price / mnt_price, and its bounds is derived from last token_ratio
        - token_ratio: [tokenRatioMin, tokenRatioMax]
        - tokenRatioMin := max(last_token_ratio*0.95, TokenRatioMin)
        - tokenRatioMax := min(last_token_ratio*1.05, TokenRatioMax)
        - TokenRatioMin: 100
        - TokenRatioMax: 10000
    - eth_price: (100, 1000000)
    - mnt_price: (0.01, 100)
- add `TOKEN_PAIR_MNT_MODE` to choose use `BIT` or `MNT` to calculate `token_ratio`

Related Issues:

- https://github.com/mantlenetworkio/mantle/issues/1054

Related PRs:
- https://github.com/mantlenetworkio/mantle/pull/1062