### PR TITLE
[R4R]Feature/internal audit check fix

### DIFF
--- a/packages/contracts/contracts/L1/delegation/DelegationShareBase.sol
+++ b/packages/contracts/contracts/L1/delegation/DelegationShareBase.sol
@@ -54,7 +54,7 @@ abstract contract DelegationShareBase is Initializable, PausableUpgradeable, IDe
         returns (uint256 newShares)
     {
         require(token == underlyingToken, "DelegationShareBase.deposit: Can only deposit underlyingToken");
-        require(amount >= 1*10**underlyingToken.decimals(), "amount must gt 1 unit");
+        // require(amount >= 1*10**underlyingToken.decimals(), "amount must gt 1 unit");
 
         /**
          * @notice calculation of newShares *mirrors* `underlyingToShares(amount)`, but is different since the balance of `underlyingToken`

--- a/packages/contracts/contracts/L1/fraud-proof/Rollup.sol
+++ b/packages/contracts/contracts/L1/fraud-proof/Rollup.sol
@@ -98,7 +98,6 @@ contract Rollup is Lib_AddressResolver, RollupBase, Whitelist {
     mapping(address => uint256) public withdrawableFunds; // mapping from addresses to withdrawable funds (won in challenge)
     Zombie[] public zombies; // stores stakers that lost a challenge
     ChallengeCtx public challengeCtx;  // stores challenge context
-
     constructor() Lib_AddressResolver(address(0)) {
         _disableInitializers();
     }

--- a/packages/contracts/contracts/L1/tss/TssGroupManager.sol
+++ b/packages/contracts/contracts/L1/tss/TssGroupManager.sol
@@ -170,8 +170,8 @@ contract TssGroupManager is
     // slither-disable-next-line external-function
     function removeMember(bytes calldata _publicKey) public override onlyOwner {
         require(
-            activeTssMembers.length > threshold,
-            "TssGroupManager removeMember: active members must more than threshold"
+            activeTssMembers.length > threshold + 1,
+            "TssGroupManager removeMember: active members must more than threshold plus one"
         );
         for (uint256 i = 0; i < activeTssMembers.length; i++) {
             if (_isEqual(activeTssMembers[i], _publicKey)) {

--- a/packages/contracts/contracts/L1/tss/TssGroupManager.sol
+++ b/packages/contracts/contracts/L1/tss/TssGroupManager.sol
@@ -169,6 +169,10 @@ contract TssGroupManager is
      */
     // slither-disable-next-line external-function
     function removeMember(bytes calldata _publicKey) public override onlyOwner {
+        require(
+            activeTssMembers.length > threshold,
+            "TssGroupManager removeMember: active members must more than threshold"
+        );
         for (uint256 i = 0; i < activeTssMembers.length; i++) {
             if (_isEqual(activeTssMembers[i], _publicKey)) {
                 _removeActiveTssMembers(i);

--- a/packages/contracts/contracts/L1/tss/TssStakingSlashing.sol
+++ b/packages/contracts/contracts/L1/tss/TssStakingSlashing.sol
@@ -228,7 +228,7 @@ contract TssStakingSlashing is
      * @param _sig the signature of the hash keccak256(_messageBytes)
      */
     function slashing(bytes calldata _messageBytes, bytes calldata _sig) public nonReentrant {
-        require(tssManager == msg.sender,"TssStakingSlashing: tss manager address is zero");
+        require(tssManager == msg.sender,"TssStakingSlashing: msg.sender is not tssManager");
         SlashMsg memory message = abi.decode(_messageBytes, (SlashMsg));
         // verify tss member state not at jailed status
         require(!isJailed(message.jailNode), "the node already jailed");

--- a/packages/contracts/contracts/da/BVM_EigenDataLayrChain.sol
+++ b/packages/contracts/contracts/da/BVM_EigenDataLayrChain.sol
@@ -274,7 +274,7 @@ contract BVM_EigenDataLayrChain is Initializable, OwnableUpgradeable, Reentrancy
         uint32 totalOperatorsIndex,
         bool   isReRollup
     ) external onlySequencer {
-        require(startL2Block == l2ConfirmedBlockNumber, "confirmData: startL2Block must equal last l2ConfirmedBlockNumber");
+        require(startL2Block == l2ConfirmedBlockNumber, "storeData: startL2Block must equal last l2ConfirmedBlockNumber");
         require(endL2Block > startL2Block, "storeData: endL2Block must more than startL2Block");
         require(block.number - blockNumber < BLOCK_STALE_MEASURE, "storeData: stakes taken from too long ago");
         uint32 dataStoreId = IDataLayrServiceManager(dataManageAddress).taskNumber();

--- a/packages/contracts/contracts/da/BVM_EigenDataLayrChain.sol
+++ b/packages/contracts/contracts/da/BVM_EigenDataLayrChain.sol
@@ -274,6 +274,7 @@ contract BVM_EigenDataLayrChain is Initializable, OwnableUpgradeable, Reentrancy
         uint32 totalOperatorsIndex,
         bool   isReRollup
     ) external onlySequencer {
+        require(startL2Block == l2ConfirmedBlockNumber, "confirmData: startL2Block must equal last l2ConfirmedBlockNumber");
         require(endL2Block > startL2Block, "storeData: endL2Block must more than startL2Block");
         require(block.number - blockNumber < BLOCK_STALE_MEASURE, "storeData: stakes taken from too long ago");
         uint32 dataStoreId = IDataLayrServiceManager(dataManageAddress).taskNumber();
@@ -314,6 +315,7 @@ contract BVM_EigenDataLayrChain is Initializable, OwnableUpgradeable, Reentrancy
         uint256 reConfirmedBatchIndex,
         bool isReRollup
     ) external onlySequencer {
+        require(startL2Block == l2ConfirmedBlockNumber, "confirmData: startL2Block must equal last l2ConfirmedBlockNumber");
         require(endL2Block > startL2Block, "confirmData: endL2Block must more than startL2Block");
         BatchRollupBlock memory batchRollupBlock = dataStoreIdToL2RollUpBlock[searchData.metadata.globalDataStoreId];
         require(batchRollupBlock.startL2BlockNumber == startL2Block &&


### PR DESCRIPTION
# Goals of PR

Core changes:

Internal audit final check and fix

- MantleDa: investmentManager contracts need check strategy for staker staking
- MantleDa: BVM_EigenDataLayrChain contracts need check startL2Block == l2ConfirmedBlockNumber for data rollup init and conform
- Tss: TssGroupManager contracts need check  activeTssMembers.length > threshold + 1 for removeMember function


Notes:

- no

Related Issues:

- https://github.com/mantlenetworkio/mantle/issues/1119
