### PR TITLE
Return error messages to avoid null pointer exceptions from occurring.

### DIFF
--- a/tss/node/tsslib/keysign/tss_keysign.go
+++ b/tss/node/tsslib/keysign/tss_keysign.go
@@ -69,7 +69,7 @@ func (tKeySign *TssKeySign) SignMessage(msgToSign []byte, localStateItem storage
 
 	if !common2.Contains(partiesID, localPartyID) {
 		tKeySign.logger.Info().Msgf("we are not in this rounds key sign")
-		return nil, nil
+		return nil, fmt.Errorf("we are not in this rounds key sign")
 	}
 
 	outCh := make(chan tss.Message, 2*len(partiesID))


### PR DESCRIPTION
# Goals of PR

Core changes:

- Return error messages to avoid null pointer exceptions from occurring

