### PR TITLE
added a storage gap to the bottom of the contract

### DIFF
--- a/packages/contracts/contracts/da/BVM_EigenDataLayrChain.sol
+++ b/packages/contracts/contracts/da/BVM_EigenDataLayrChain.sol
@@ -403,4 +403,6 @@ contract BVM_EigenDataLayrChain is Initializable, OwnableUpgradeable, Reentrancy
             dataStoreIdToL2RollUpBlock[searchData.metadata.globalDataStoreId].endBL2BlockNumber
         );
     }
+
+    uint256[49] private __gap;
 }


### PR DESCRIPTION
# Goals of PR
Resolves https://github.com/mantlenetworkio/mantle/issues/1065

Core changes:
- New 49 256 bit word at the bottom of one contract which lives behind a proxy

Notes:
- currently untested since testing command is broken, see https://github.com/mantlenetworkio/mantle/issues/1099