### PR TITLE
[R4R] - {develop}: Remove unavailableFraudProofAddress function

### DIFF
--- a/packages/contracts/contracts/da/BVM_EigenDataLayrChain.sol
+++ b/packages/contracts/contracts/da/BVM_EigenDataLayrChain.sol
@@ -136,16 +136,7 @@ contract BVM_EigenDataLayrChain is Initializable, OwnableUpgradeable, Reentrancy
         require(_address != address(0), "setFraudProofAddress: address is the zero address");
         fraudProofWhitelist[_address] = true;
     }
-
-    /**
-    * @notice unavailable fraud proof address
-    * @param _address for fraud proof
-    */
-    function unavailableFraudProofAddress(address _address) external onlySequencer {
-        require(_address != address(0), "unavailableFraudProofAddress: unavailableFraudProofAddress: address is the zero address");
-        fraudProofWhitelist[_address] = false;
-    }
-
+    
     /**
     * @notice remove fraud proof address
     * @param _address for fraud proof


### PR DESCRIPTION
# Goals of PR

Core changes:

- The functions removeFraudProofAddress() and unavailableFraudProofAddress() in the BVM_EigenDataLayrchain contract are equivalent so Remove unavailableFraudProofAddress() function.

Notes:

- no

Related Issues:

- https://github.com/mantlenetworkio/mantle/issues/1175
