### PR TITLE
[R4R][l2geth]hotfix: fix update upgrade gas limit

### DIFF
--- a/l2geth/consensus/clique/clique.go
+++ b/l2geth/consensus/clique/clique.go
@@ -586,7 +586,7 @@ func (c *Clique) FinalizeAndAssemble(chain consensus.ChainReader, header *types.
 	//if UpdateGasLimitBlock = 0, from the genesis block
 	//if UpdateGasLimitBlock = x, from the x
 	mantleUpgradeConfig := upgrade.NewMantleUpgradeConfig(chain.Config().ChainID)
-	if !mantleUpgradeConfig.IsUpdateGasLimitBlock(header.Number) {
+	if !mantleUpgradeConfig.IsUpdateGasLimitBlock(header.Number) && chain.Config().ChainID == params.MantleTestnetChainID {
 		//for testnet, when the UpdateGasLimitBlock  is actived, we must update the gaslimit for all of block
 		//which is after the "updategaslimit" block
 		header.GasLimit = uint64(upgrade.PreUpgradedGaslimit)


### PR DESCRIPTION
# Goals of PR

Core changes:

- bugfix: `gas limit upgrade` just  available for testnet, not mainnet
- mainnet's `gas limit` is set to `30,000,000` from genesis

Related Issues:

- #1005 
