### PR TITLE
[R4R] - {develop}: Simplify error formatting

### DIFF
--- a/tss/manager/agreement.go
+++ b/tss/manager/agreement.go
@@ -3,8 +3,9 @@ package manager
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"sync"
+
 	"github.com/influxdata/influxdb/pkg/slices"
 	"github.com/mantlenetworkio/mantle/l2geth/log"
 	tss "github.com/mantlenetworkio/mantle/tss/common"
@@ -12,7 +13,6 @@ import (
 	"github.com/mantlenetworkio/mantle/tss/ws/server"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	tmtypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
-	"sync"
 )
 
 func (m Manager) agreement(ctx types.Context, request interface{}, method tss.Method) (types.Context, error) {
@@ -102,7 +102,7 @@ func (m Manager) agreement(ctx types.Context, request interface{}, method tss.Me
 	wg.Wait()
 
 	if len(results) < ctx.TssInfos().Threshold+1 {
-		return types.Context{}, errors.New(fmt.Sprintf("not enough response, %d nodes response for the ask result, we need at least %d nodes to complete the signing process", len(results), ctx.TssInfos().Threshold+1))
+		return types.Context{}, fmt.Errorf("not enough response, %d nodes response for the ask result, we need at least %d nodes to complete the signing process", len(results), ctx.TssInfos().Threshold+1)
 	}
 
 	approvers := make([]string, 0)

--- a/tss/node/tsslib/keysign.go
+++ b/tss/node/tsslib/keysign.go
@@ -187,7 +187,7 @@ func (t *TssServer) isContainPubkeys(signerPubKeys, participants []string, poolP
 		}
 	}
 	if len(errPubkyes) != 0 {
-		return errors.New(fmt.Sprintf("these pub keys %s are not members of %s's participants", strings.Join(errPubkyes, ","), poolPubkey))
+		return fmt.Errorf("these pub keys %s are not members of %s's participants", strings.Join(errPubkyes, ","), poolPubkey)
 	}
 	return nil
 }

--- a/tss/ws/server/handler.go
+++ b/tss/ws/server/handler.go
@@ -110,7 +110,7 @@ func (wm *WebsocketManager) SendMsg(msg RequestMsg) error {
 	defer wm.scRWLock.RUnlock()
 	sendChan, ok := wm.sendChan[msg.TargetNode]
 	if !ok {
-		return errors.New(fmt.Sprintf("the node(%s) is lost", msg.TargetNode))
+		return fmt.Errorf("the node(%s) is lost", msg.TargetNode)
 	}
 	go func() {
 		sendChan <- msg.RpcRequest


### PR DESCRIPTION

# Goals of PR

Core changes:

- Simplify error formatting by replacing instances of errors.New(fmt.Sprintf()) with the more streamlined fmt.Errorf() throughout the code base.

Notes:

- Write notes here

Related Issues:

[- Link issues here
](https://github.com/mantlenetworkio/mantle/issues/1192)