### PR TITLE
[R4R] - {sdk}: align standard-bridge with selected chain

### DIFF
--- a/packages/sdk/src/adapters/standard-bridge.ts
+++ b/packages/sdk/src/adapters/standard-bridge.ts
@@ -23,7 +23,7 @@ import {
   TokenBridgeMessage,
   MessageDirection,
 } from '../interfaces'
-import { toAddress } from '../utils'
+import { toAddress, L1_MNT_ADDRESS } from '../utils'
 
 /**
  * Bridge adapter for any token bridge that uses the standard token bridge interface.
@@ -173,10 +173,9 @@ export class StandardBridgeAdapter implements IBridgeAdapter {
         return false
       }
 
-      // Make sure the L1 token matches.
+      // Make sure the L1 token matches the L1_MNT_ADDRESS associated with this l2ChainId
       const remoteL1Token = await contract.l1Token()
-
-      if (hexStringEquals(remoteL1Token, toAddress('0x3c3a81e81dc49A522A592e7622A7E711c06bf354'))){
+      if (hexStringEquals(remoteL1Token, toAddress(L1_MNT_ADDRESS[this.messenger.l2ChainId]))){
         return true
       }
 

--- a/packages/sdk/src/utils/contracts.ts
+++ b/packages/sdk/src/utils/contracts.ts
@@ -49,6 +49,20 @@ const NAME_REMAPPING = {
 }
 
 /**
+ * Mapping of L2 chain IDs to MNT contract addresses to detect correct token in standard-bridge
+ */
+export const L1_MNT_ADDRESS: {
+  [ChainID in L2ChainID]: string
+} = {
+  [L2ChainID.MANTLE]: "0x3c3a81e81dc49A522A592e7622A7E711c06bf354",
+  [L2ChainID.MANTLE_KOVAN]: "0x3c3a81e81dc49A522A592e7622A7E711c06bf354",
+  [L2ChainID.MANTLE_GOERLIQA]: "0x3c3a81e81dc49A522A592e7622A7E711c06bf354",
+  [L2ChainID.MANTLE_TESTNET]: "0xc1dC2d65A2243c22344E725677A3E3BEBD26E604",
+  [L2ChainID.MANTLE_HARDHAT_LOCAL]: "0x3c3a81e81dc49A522A592e7622A7E711c06bf354",
+  [L2ChainID.MANTLE_HARDHAT_DEVNET]: "0x3c3a81e81dc49A522A592e7622A7E711c06bf354"
+}
+
+/**
  * Mapping of L1 chain IDs to the appropriate contract addresses for the OE deployments to the
  * given network. Simplifies the process of getting the correct contract addresses for a given
  * contract name.


### PR DESCRIPTION
# Goals of PR

Core changes:

- Defines a mapping between `L1_MNT_ADDRESS` and `L2_CHAIN_ID` so that we can check against the correct `MNT` address in the standard-bridge.
