### PR TITLE
[R4R]-{develop}: Upgrade docker actions to add support for multiple platforms

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -87,14 +87,18 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME || 'mantlenetworkio' }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }}
+          
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Publish L2Geth
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: ./l2geth/Dockerfile
           push: true
           tags: mantlenetworkio/l2geth:${{ needs.release.outputs.l2geth }},mantlenetworkio/l2geth:latest


### PR DESCRIPTION
# Add support for linux/arm64

Core changes:

- Added qemu action needed to build image to multiple platform and upgraded `docker/setup-buildx-action`  and `docker/build-push-action`

Notes:

- Was not able to build from https://github.com/mantlenetworkio/networks/blob/main/docker-compose.yml using `arm64` platform