### PR TITLE
[R4R]- {develop}: l2geth exclude mantleDa dependence so that it can build binary

### DIFF
--- a/l2geth/go.mod
+++ b/l2geth/go.mod
@@ -8,6 +8,10 @@ replace github.com/mantlenetworkio/mantle/bss-core => ../bss-core
 
 replace github.com/mantlenetworkio/mantle/metrics => ../metrics
 
+exclude github.com/Layr-Labs/datalayr/common v0.0.0
+
+exclude github.com/Layr-Labs/datalayr/lib/merkzg v0.0.0
+
 require (
 	github.com/Azure/azure-storage-blob-go v0.7.0
 	github.com/VictoriaMetrics/fastcache v1.9.0


### PR DESCRIPTION
# Goals of PR

Core changes:

- l2geth exclude mantleDa dependence so that it can build binary

Notes:

- no

Related Issues:

- no
