### PR TITLE
[R4R]-{develop}-[gasoracle]impr: modify token_ratio from int64 to float64 for metrics

### DIFF
--- a/gas-oracle/metrics/metrics.go
+++ b/gas-oracle/metrics/metrics.go
@@ -15,7 +15,7 @@ var (
 
 		// metrics for L1 base fee, L1 bas price, da fee
 		// TokenRatioGauge token_ratio = eth_price / mnt_price
-		TokenRatioGauge metrics.Gauge
+		TokenRatioGauge metrics.GaugeFloat64
 		// L1BaseFeeGauge (l1_base_fee + l1_priority_fee) * token_ratio
 		L1BaseFeeGauge metrics.Gauge
 		// FeeScalarGauge value to scale the fee up by
@@ -44,7 +44,7 @@ func InitAndRegisterStats(r metrics.Registry) {
 	GasOracleStats.TxSendTimer = metrics.NewRegisteredTimer("tx/send", r)
 
 	// stats for L1 base fee, L1 bas price, da fee
-	GasOracleStats.TokenRatioGauge = metrics.NewRegisteredGauge("token_ratio", r)
+	GasOracleStats.TokenRatioGauge = metrics.NewRegisteredGaugeFloat64("token_ratio", r)
 	GasOracleStats.L1BaseFeeGauge = metrics.NewRegisteredGauge("l1_base_fee", r)
 	GasOracleStats.FeeScalarGauge = metrics.NewRegisteredGauge("fee_scalar", r)
 	GasOracleStats.DaFeeGauge = metrics.NewRegisteredGauge("da_fee", r)

--- a/gas-oracle/oracle/l1_client.go
+++ b/gas-oracle/oracle/l1_client.go
@@ -53,7 +53,7 @@ func (c *L1Client) HeaderByNumber(ctx context.Context, number *big.Int) (*types.
 	tip.BaseFee = new(big.Int).Mul(new(big.Int).Add(bestBaseFee, gasTipCap), big.NewInt(int64(ratio)))
 	log.Info("show base fee context", "bestBaseFee", bestBaseFee, "gasTipCap", gasTipCap, "ratio", ratio)
 	ometrics.GasOracleStats.L1GasPriceGauge.Update(new(big.Int).Add(bestBaseFee, gasTipCap).Int64())
-	ometrics.GasOracleStats.TokenRatioGauge.Update(int64(ratio))
+	ometrics.GasOracleStats.TokenRatioGauge.Update(ratio)
 	return tip, nil
 }
 


### PR DESCRIPTION
# Goals of PR

Core changes:
- modify token_ratio from `int64` to `float64` for metrics
- solve the false alarm from monitor 

Issues:
- when using the `int64` data type, the changes on the decimal places will be eliminated

Solutions:
- replace `metrics.Gauge` with `metrics.GaugeFloat64` to store `token_ratio`

Results:
![截屏2023-07-21 11 30 54](https://github.com/mantlenetworkio/mantle/assets/17921243/f53ebcf0-dab5-4451-b90a-eed62a043594)

