### PR TITLE
[R4R]-{develop}:resolve DA verifier may cause a 'nonce too high' error.

### DIFF
--- a/l2geth/rollup/sync_service.go
+++ b/l2geth/rollup/sync_service.go
@@ -1456,14 +1456,8 @@ func (s *SyncService) syncEigenTransactionBatchRange(start, end uint64) error {
 					return fmt.Errorf("cannot get eigen transaction batch from dtl: %w", err)
 				}
 				for _, tx := range txs {
-					verified, err := s.verifyTx(tx)
-					if err != nil {
-						return err
-					}
-					if verified {
-						if err := s.applyBatchedTransaction(tx); err != nil {
-							return fmt.Errorf("cannot apply batched transaction: %w", err)
-						}
+					if err := s.applyBatchedTransaction(tx); err != nil {
+						return fmt.Errorf("cannot apply batched transaction: %w", err)
 					}
 				}
 				log.Info("set latest eigen batch index", "index", i)
@@ -1480,14 +1474,8 @@ func (s *SyncService) syncEigenTransactionBatchRange(start, end uint64) error {
 					return fmt.Errorf("cannot get eigen transaction batch: %w", err)
 				}
 				for _, tx := range txs {
-					verified, err := s.verifyTx(tx)
-					if err != nil {
-						return err
-					}
-					if verified {
-						if err := s.applyBatchedTransaction(tx); err != nil {
-							return fmt.Errorf("cannot apply batched transaction: %w", err)
-						}
+					if err := s.applyBatchedTransaction(tx); err != nil {
+						return fmt.Errorf("cannot apply batched transaction: %w", err)
 					}
 				}
 				log.Info("set latest eigen batch index", "index", i)


### PR DESCRIPTION
# Goals of PR

Core changes:
- Resolve DA verifier may cause a 'nonce too high' error.

Notes:
- no

Related Issues:
- https://github.com/mantlenetworkio/mantle/issues/1311
