### PR TITLE
R4R: dump witness for bedrock migration

### DIFF
--- a/l2geth/core/state/statedb.go
+++ b/l2geth/core/state/statedb.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mantlenetworkio/mantle/l2geth/rlp"
 	"github.com/mantlenetworkio/mantle/l2geth/rollup/dump"
 	"github.com/mantlenetworkio/mantle/l2geth/rollup/rcfg"
+	"github.com/mantlenetworkio/mantle/l2geth/statedumper"
 	"github.com/mantlenetworkio/mantle/l2geth/trie"
 	"golang.org/x/crypto/sha3"
 )
@@ -244,6 +245,7 @@ func (s *StateDB) GetBalance(addr common.Address) *big.Int {
 	if rcfg.UsingBVM {
 		// Get balance from the bvm_ETH contract.
 		// NOTE: We may remove this feature in a future release.
+		statedumper.WriteETH(addr)
 		key := GetbvmBalanceKey(addr)
 		bal := s.GetState(dump.BvmMantleAddress, key)
 		return bal.Big()
@@ -373,6 +375,7 @@ func (s *StateDB) HasSuicided(addr common.Address) bool {
 // AddBalance adds amount to the account associated with addr.
 func (s *StateDB) AddBalance(addr common.Address, amount *big.Int) {
 	if rcfg.UsingBVM {
+		statedumper.WriteETH(addr)
 		// Mutate the storage slot inside of bvm_ETH to change balances.
 		// Note that we don't need to check for overflows or underflows here because the code that
 		// uses this codepath already checks for them. You can follow the original codepath below
@@ -393,6 +396,7 @@ func (s *StateDB) AddBalance(addr common.Address, amount *big.Int) {
 // SubBalance subtracts amount from the account associated with addr.
 func (s *StateDB) SubBalance(addr common.Address, amount *big.Int) {
 	if rcfg.UsingBVM {
+		statedumper.WriteETH(addr)
 		// Mutate the storage slot inside of bvm_ETH to change balances.
 		// Note that we don't need to check for overflows or underflows here because the code that
 		// uses this codepath already checks for them. You can follow the original codepath below
@@ -412,6 +416,7 @@ func (s *StateDB) SubBalance(addr common.Address, amount *big.Int) {
 
 func (s *StateDB) SetBalance(addr common.Address, amount *big.Int) {
 	if rcfg.UsingBVM {
+		statedumper.WriteETH(addr)
 		// Mutate the storage slot inside of bvm_ETH to change balances.
 		key := GetbvmBalanceKey(addr)
 		s.SetState(dump.BvmMantleAddress, key, common.BigToHash(amount))

--- a/l2geth/rollup/dump/constants.go
+++ b/l2geth/rollup/dump/constants.go
@@ -10,3 +10,4 @@ var TssRewardAddress = common.HexToAddress("0x4200000000000000000000000000000000
 var DeadAddress = common.HexToAddress("0xdeaDDeADDEaDdeaDdEAddEADDEAdDeadDEADDEaD")
 var BvmWhitelistAddress = common.HexToAddress("0x4200000000000000000000000000000000000002")
 var BvmRollbackAddress = common.HexToAddress("0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD2222")
+var MessagePasserAddress = common.HexToAddress("0x4200000000000000000000000000000000000000")

--- a/l2geth/statedumper/dumper.go
+++ b/l2geth/statedumper/dumper.go
@@ -1,0 +1,82 @@
+package statedumper
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/mantlenetworkio/mantle/l2geth/common"
+)
+
+type StateDumper interface {
+	WriteETH(address common.Address)
+	WriteMessage(sender common.Address, msg []byte)
+}
+
+var DefaultStateDumper StateDumper
+
+func NewStateDumper() StateDumper {
+	path := os.Getenv("L2GETH_STATE_DUMP_PATH")
+	if path == "" {
+		return &noopStateDumper{}
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o755)
+	if err != nil {
+		panic(err)
+	}
+
+	return &FileStateDumper{
+		f:        f,
+		ethCache: make(map[common.Address]bool),
+	}
+}
+
+type FileStateDumper struct {
+	f        io.Writer
+	ethCache map[common.Address]bool
+	mtx      sync.Mutex
+}
+
+func (s *FileStateDumper) WriteETH(address common.Address) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if s.ethCache[address] {
+		return
+	}
+	s.ethCache[address] = true
+
+	if _, err := s.f.Write([]byte(fmt.Sprintf("ETH|%s\n", address.Hex()))); err != nil {
+		panic(err)
+	}
+}
+
+func (s *FileStateDumper) WriteMessage(sender common.Address, msg []byte) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if _, err := s.f.Write([]byte(fmt.Sprintf("MSG|%s|%x\n", sender.Hex(), msg))); err != nil {
+		panic(err)
+	}
+}
+
+type noopStateDumper struct {
+}
+
+func (n *noopStateDumper) WriteETH(address common.Address) {
+}
+
+func (n *noopStateDumper) WriteMessage(sender common.Address, msg []byte) {
+}
+
+func init() {
+	DefaultStateDumper = NewStateDumper()
+}
+
+func WriteETH(address common.Address) {
+	DefaultStateDumper.WriteETH(address)
+}
+
+func WriteMessage(sender common.Address, msg []byte) {
+	DefaultStateDumper.WriteMessage(sender, msg)
+}

--- a/l2geth/statedumper/dumper_test.go
+++ b/l2geth/statedumper/dumper_test.go
@@ -1,0 +1,36 @@
+package statedumper
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/mantlenetworkio/mantle/l2geth/common"
+)
+
+func TestFileStateDumper(t *testing.T) {
+	f, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatalf("error creating file: %v", err)
+	}
+	err = os.Setenv("L2GETH_STATE_DUMP_PATH", f.Name())
+	if err != nil {
+		t.Fatalf("error setting env file: %v", err)
+	}
+	dumper := NewStateDumper()
+	addr := common.Address{19: 0x01}
+	dumper.WriteETH(addr)
+	dumper.WriteMessage(addr, []byte("hi"))
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		t.Fatalf("error seeking: %v", err)
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("error reading: %v", err)
+	}
+	dataStr := string(data)
+	if dataStr != "ETH|0x0000000000000000000000000000000000000001\nMSG|0x0000000000000000000000000000000000000001|6869\n" {
+		t.Fatalf("invalid data. got: %s", dataStr)
+	}
+}


### PR DESCRIPTION
# Goals of PR

Core changes:

- Add **statedumper** in l2geth to generate witness file which is necessary for bedrock upgrade
- Anyone can run a replica node to sync data, once the replica node reach bedrock upgrade height, then the witness file is completed.
- By default, **statedumper** is closed. It can be opened by setting up an environment variable **L2GETH_STATE_DUMP_PATH**
- To generate a full witness file, the replica node must set up the environment variable and sync data from the beginning to the height before bedrock upgrade height.

Notes:

- Write notes here

Related Issues:

- Link issues here
