### PR TITLE
R4R: DTL stop sync TransactionEnqueued event once DTL_SHUTOFF_BLOCK is set 

### DIFF
--- a/packages/contracts/deploy/011-AddressDictator.deploy.ts
+++ b/packages/contracts/deploy/011-AddressDictator.deploy.ts
@@ -1,6 +1,6 @@
 /* Imports: External */
 import { DeployFunction } from 'hardhat-deploy/dist/types'
-import { hexStringEquals } from '@mantleio/core-utils'
+import { hexStringEquals, sleep } from '@mantleio/core-utils'
 
 /* Imports: Internal */
 import {
@@ -74,6 +74,8 @@ const deployFn: DeployFunction = async (hre) => {
   namesAndAddresses = namesAndAddresses.filter(({ name, address }) => {
     return !hexStringEquals(existingAddresses[name], address)
   })
+
+  await sleep(10000)
 
   await deployAndVerifyAndThen({
     hre,

--- a/packages/contracts/tasks/fraud-proof-tasks.ts
+++ b/packages/contracts/tasks/fraud-proof-tasks.ts
@@ -1,6 +1,6 @@
 import { task } from 'hardhat/config'
 import { ethers } from 'ethers'
-import { hexStringEquals } from '@mantleio/core-utils'
+import {hexStringEquals, sleep} from '@mantleio/core-utils'
 
 // @ts-ignore
 import { getContractFactory } from '../src'
@@ -112,6 +112,7 @@ task('rollupStake')
       }
 
       await mantle.connect(deployer).transfer(stakerWallet.address, mantleAmount)
+      await sleep(10000)
       console.log(
         'balance: ',
         stakerWallet.address,
@@ -122,22 +123,29 @@ task('rollupStake')
         'ETH Balance:',
         stakerWallet.address,
         ' ',
-        await stakerWallet.getBalance()
+        (await stakerWallet.getBalance()).toString()
       )
+      await sleep(10000)
       await mantle
         .connect(stakerWallet)
         .approve(taskArgs.rollup, ethers.utils.parseEther(taskArgs.amount))
+
+      await sleep(10000);
       console.log(
         'ETH Balance:',
         stakerWallet.address,
         ' ',
-        await stakerWallet.getBalance()
+        (await stakerWallet.getBalance()).toString()
       )
+
+      await sleep(10000)
 
       console.log('stake', stakerWallet.address, operators[i])
       await rollup
         .connect(stakerWallet)
         .stake(ethers.utils.parseEther(taskArgs.amount), operators[i])
+
+      await sleep(10000)
     }
   })
 

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -4,7 +4,7 @@ import { BaseService, Metrics } from '@mantleio/common-ts'
 import { TypedEvent } from '@mantleio/contracts/dist/types/common'
 import { BaseProvider, StaticJsonRpcProvider } from '@ethersproject/providers'
 import { LevelUp } from 'levelup'
-import { constants } from 'ethers'
+import { BigNumber, constants } from 'ethers'
 import { Gauge, Counter } from 'prom-client'
 
 /* Imports: Internal */
@@ -213,10 +213,18 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
         await this.state.db.putHighestL1BlockNumber(currentL1Block)
         await this.state.db.putFraudProofWindow(fraudProofWindow)
 
-        const targetL1Block = Math.min(
+        let targetL1Block = Math.min(
           highestSyncedL1Block + this.options.logsPerPollingInterval,
           currentL1Block - this.options.confirmations
         )
+
+        // Don't sync beyond the shutoff block!
+        if (Number.isInteger(this.options.l1SyncShutoffBlock)) {
+          targetL1Block = Math.min(
+            targetL1Block,
+            this.options.l1SyncShutoffBlock
+          )
+        }
 
         // We're already at the head, so no point in attempting to sync.
         if (highestSyncedL1Block === targetL1Block) {
@@ -260,16 +268,44 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
           targetL1Block,
         })
 
-        // I prefer to do this in serial to avoid non-determinism. We could have a discussion about
-        // using Promise.all if necessary, but I don't see a good reason to do so unless parsing is
-        // really, really slow for all event types.
-        await this._syncEvents(
-          'CanonicalTransactionChain',
-          'TransactionEnqueued',
-          highestSyncedL1Block,
-          targetL1Block,
-          handleEventsTransactionEnqueued
-        )
+        // We always try loading the deposit shutoff block in every loop! Less efficient but will
+        // guarantee that we don't miss the shutoff block being set and that we can automatically
+        // recover if the shutoff block is set and then unset.
+        const depositShutoffBlock = BigNumber.from(
+          await this.state.contracts.Lib_AddressManager.getAddress(
+            'DTL_SHUTOFF_BLOCK'
+          )
+        ).toNumber()
+
+        // If the deposit shutoff block is set, then we should stop syncing deposits at that block.
+        let depositTargetL1Block = targetL1Block
+        if (depositShutoffBlock > 0) {
+          this.logger.info(`Deposit shutoff active`, {
+            targetL1Block,
+            depositShutoffBlock,
+          })
+          depositTargetL1Block = Math.min(
+            depositTargetL1Block,
+            depositShutoffBlock
+          )
+        }
+
+        // We should not sync TransactionEnqueued events beyond the deposit shutoff block.
+        if (depositTargetL1Block >= highestSyncedL1Block) {
+          await this._syncEvents(
+            'CanonicalTransactionChain',
+            'TransactionEnqueued',
+            highestSyncedL1Block,
+            depositTargetL1Block,
+            handleEventsTransactionEnqueued
+          )
+        } else {
+          this.logger.info('Deposit shutoff reached', {
+            depositTargetL1Block,
+            highestSyncedL1Block,
+            depositShutoffBlock,
+          })
+        }
 
         if (!this.options.eigenUpgradeEnable) {
           await this._syncEvents(

--- a/packages/data-transport-layer/src/services/l1-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l1-ingestion/service.ts
@@ -213,18 +213,10 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
         await this.state.db.putHighestL1BlockNumber(currentL1Block)
         await this.state.db.putFraudProofWindow(fraudProofWindow)
 
-        let targetL1Block = Math.min(
+        const targetL1Block = Math.min(
           highestSyncedL1Block + this.options.logsPerPollingInterval,
           currentL1Block - this.options.confirmations
         )
-
-        // Don't sync beyond the shutoff block!
-        if (Number.isInteger(this.options.l1SyncShutoffBlock)) {
-          targetL1Block = Math.min(
-            targetL1Block,
-            this.options.l1SyncShutoffBlock
-          )
-        }
 
         // We're already at the head, so no point in attempting to sync.
         if (highestSyncedL1Block === targetL1Block) {

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -27,7 +27,6 @@ export interface L1DataTransportServiceOptions {
   l2RpcProvider: string
   l2RpcProviderUser?: string
   l2RpcProviderPassword?: string
-  l1SyncShutoffBlock?: number
   metrics?: Metrics
   dbPath: string
   logsPerPollingInterval: number

--- a/packages/data-transport-layer/src/services/main/service.ts
+++ b/packages/data-transport-layer/src/services/main/service.ts
@@ -27,6 +27,7 @@ export interface L1DataTransportServiceOptions {
   l2RpcProvider: string
   l2RpcProviderUser?: string
   l2RpcProviderPassword?: string
+  l1SyncShutoffBlock?: number
   metrics?: Metrics
   dbPath: string
   logsPerPollingInterval: number


### PR DESCRIPTION
# Goals of PR

Core changes:

- Preparing for bedrock upgrade, **DTL** stop sync **TransactionEnqueued event** once DTL_SHUTOFF_BLOCK is set in addressManager
- Add sleep in deploy scripts to accommodate normal l1 blockchain(produce blocks periodically)
