### PR TITLE
[R4R]-{develop}: fix mt-batcher pushes one less block

### DIFF
--- a/mt-batcher/services/sequencer/driver.go
+++ b/mt-batcher/services/sequencer/driver.go
@@ -235,7 +235,7 @@ func (d *Driver) GetBatchBlockRange(ctx context.Context) (*big.Int, *big.Int, er
 		return nil, nil, fmt.Errorf("invalid range, end(%v) < start(%v)", end, start)
 	}
 	if end.Cmp(latestHeader.Number) > 0 {
-		end = latestHeader.Number
+		end = new(big.Int).Add(latestHeader.Number, bigOne)
 	}
 	return start, end, nil
 }

--- a/packages/data-transport-layer/src/services/da-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/da-ingestion/service.ts
@@ -448,6 +448,9 @@ export class DaIngestionService extends BaseService<DaIngestionServiceOptions> {
             )
             return false
           }
+          this.daIngestionMetrics.currentL2TransactionIndex.set(
+            batchTx['TxMeta']['index']
+          )
         }
         transactionEntries.push({
           index: batchTx['TxMeta']['index'],
@@ -464,9 +467,6 @@ export class DaIngestionService extends BaseService<DaIngestionServiceOptions> {
           decoded,
           confirmed: true,
         })
-        this.daIngestionMetrics.currentL2TransactionIndex.set(
-          batchTx['TxMeta']['index']
-        )
       }
       await this.state.db.putTransactions(transactionEntries)
       await this.state.db.putBatchTransactionByDsId(


### PR DESCRIPTION
# Goals of PR

Core changes:

1. mt-batcher adds a block when pushing each batch
2. This metric is only pushed when the batch exists.

Notes:

- no

Related Issues:

- https://github.com/mantlenetworkio/mantle/issues/1366
