### PR TITLE
bug fix about estimateGas rpc parameters

### DIFF
--- a/l2geth/core/state_transition.go
+++ b/l2geth/core/state_transition.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 
@@ -299,6 +300,10 @@ func (st *StateTransition) TransitionDb() (ret []byte, usedGas uint64, vmerr err
 	if err != nil {
 		return nil, 0, err, err
 	}
+	if st.gas < gas {
+		return nil, 0, nil, fmt.Errorf("%w: have %d, want %d", ErrIntrinsicGas, st.gas, gas)
+	}
+
 	if err = st.useGas(gas); err != nil {
 		return nil, 0, err, err
 	}


### PR DESCRIPTION
# Goals of PR

Core changes:

Regarding the DoEstimateGas method in l2geth/internal/ethapi/api.go,
```go
result, err := DoCall(ctx, b, args, blockNrOrHash, nil, &vm.Config{}, 0, gasCap)
if err != nil {
    if errors.Is(err, core.ErrIntrinsicGas) {
        return true, nil, nil // Special case, raise gas limit
    }
    return true, nil, err
}
```
A new error scenario has been added in l2geth/core/state_transition.go : when the gas for StateTransition is less than the intrinsic gas, the ErrIntrinsicGas exception is thrown.
