### PR TITLE
[l2geth]: RPC support query block with safe and finalized

### DIFF
--- a/l2geth/rpc/types.go
+++ b/l2geth/rpc/types.go
@@ -96,6 +96,12 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	case "pending":
 		*bn = PendingBlockNumber
 		return nil
+	case "finalized":
+		*bn = LatestBlockNumber
+		return nil
+	case "safe":
+		*bn = LatestBlockNumber
+		return nil
 	}
 
 	blckNum, err := hexutil.DecodeUint64(input)


### PR DESCRIPTION
# Goals of PR

Core changes:

- RPC support query block with safe and finalized

Notes:

- The Ethereum network does not yet support query blocks with unsafe

Related Issues:

- https://github.com/mantlenetworkio/mantle/issues/1384
