### PR TITLE
Fix: Corrected typos in source files

### DIFF
--- a/batch-submitter/tss-client/client.go
+++ b/batch-submitter/tss-client/client.go
@@ -81,6 +81,6 @@ func (c *Client) GetSignStateBatch(BatchData common.SignStateRequest) ([]byte, e
 	if response.StatusCode() == 200 {
 		return response.Body(), nil
 	} else {
-		return nil, errors.New("fetch tss manager signature faill")
+		return nil, errors.New("fetch tss manager signature fail")
 	}
 }

--- a/fraud-proof/proof/prover.go
+++ b/fraud-proof/proof/prover.go
@@ -393,7 +393,7 @@ func generateStartBlockState(backend Backend, ctx context.Context, startBlock *t
 	if config != nil && config.Reexec != nil {
 		reexec = *config.Reexec
 	}
-	// The statedb here is the state at the end of the parent blcok
+	// The statedb here is the state at the end of the parent block
 	statedb, err := backend.StateAtBlock(ctx, startBlock, reexec, nil, true, false)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
### Changes
1. Corrected typo in fraud-proof/proof/prover.go:396:
"blcok" corrected to "block". 
2. Corrected typo in batch-submitter/tss-client/client.go:84:
"faill" corrected to "fail".

### Purpose
- Improved code accuracy and professionalism by fixing typos.
